### PR TITLE
Fix - Search both public and private stories when resolving by slug

### DIFF
--- a/utils/prezly/api/queries.ts
+++ b/utils/prezly/api/queries.ts
@@ -1,10 +1,15 @@
+const publishedAndAccessible = [
+    { lifecycle_status: { $in: ['published'] } },
+    { visibility: { $in: ['public', 'private'] } },
+];
+
 const publishedAndPublic = [
     { lifecycle_status: { $in: ['published'] } },
     { visibility: { $in: ['public'] } },
 ];
 
 export const getSlugQuery = (slug: string) => ({
-    $and: [{ slug: { $eq: slug } }, ...publishedAndPublic],
+    $and: [{ slug: { $eq: slug } }, ...publishedAndAccessible],
 });
 
 export const getStoriesQuery = (newsroomUuid: string, categoryId?: number, locale?: string) => {


### PR DESCRIPTION
Just a bug I've discovered when trying to access a private story from The Good Newsroom to debug something.

Example: https://theme-nextjs-bea-the-good-newsroom-git-feature-t-955e6b-prezly1.vercel.app/testing-text-and-all-components