### PR TITLE
Fix - Make sure story images are correctly expanded/full width

### DIFF
--- a/components/SlateRenderer/SlateRenderer.module.scss
+++ b/components/SlateRenderer/SlateRenderer.module.scss
@@ -50,6 +50,7 @@
         }
         
         .prezly-slate-image-rollover {
+            width: 100%;
             z-index: 0;
         }
 


### PR DESCRIPTION
I'm still not sure why the `width: 100%;` is required here as it's not required in legacy newsrooms but it fixes the issue. Probably because of the difference in layout HTML.

This bug is also present in the Marcel and Syrah theme.