### PR TITLE
Fix - Tweaked contact card grid rendering

### DIFF
--- a/components/ContactCard/ContactCard.module.scss
+++ b/components/ContactCard/ContactCard.module.scss
@@ -39,6 +39,7 @@
 
 .links {
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: $spacing-4 0;
     margin: $spacing-2 auto 0;
 


### PR DESCRIPTION
The problem here was that by using just `min-content` ellipsis did not work as the grid simply stretched infinitely.

With the tweak in this PR the columns will stretch if there's space but otherwise will limit its width so that everything fits nicely (and text ellipsis works).

All information filled in:
![Screenshot 2021-11-15 at 11 09 45](https://user-images.githubusercontent.com/4209081/141763129-3435c8be-aeaf-4b9b-a5d7-8736902c4c1b.png)

Just email and website:
![Screenshot 2021-11-15 at 11 09 56](https://user-images.githubusercontent.com/4209081/141763133-035d700e-3ce1-454c-a904-6233a718a8f3.png)
