### PR TITLE
[TITS-4966] Align actions to the right for desktop screens

### DIFF
--- a/modules/analytics/components/CookieConsentBar/CookieConsentBar.module.scss
+++ b/modules/analytics/components/CookieConsentBar/CookieConsentBar.module.scss
@@ -63,6 +63,10 @@
 }
 
 .actions {
+    @include desktop-up {
+        text-align: right;
+    }
+
     @include not-desktop {
         display: flex;
         flex-wrap: wrap;


### PR DESCRIPTION
Translations that fit into one row will look the same, except the notice text will be aligned to the right:

![Screenshot 2021-12-10 at 13 55 31](https://user-images.githubusercontent.com/4209081/145577704-faa3b72b-cf32-4e53-a8ba-363aed7b2f8c.png)

For translations that do not fit, the buttons are also aligned to the right:

![Screenshot 2021-12-10 at 13 55 13](https://user-images.githubusercontent.com/4209081/145577696-3059e1eb-d131-4d63-8833-ed9c458b5d01.png)
