### PR TITLE
[TITS-4964] Use native_name from SDK instead of Intl.DisplayNames

### DIFF
--- a/modules/Layout/Header/LanguagesDropdown/LanguagesDropdown.tsx
+++ b/modules/Layout/Header/LanguagesDropdown/LanguagesDropdown.tsx
@@ -29,19 +29,23 @@ const LanguagesDropdown: FunctionComponent<Props> = ({
     const getLinkLocaleSlug = useGetLinkLocaleSlug();
     const { hasError } = useNewsroomContext();
 
-    const displayedLocales = useMemo(() => {
+    const currentLanguage = useMemo(
+        () => languages.find((language) => language.code === currentLocale.toUnderscoreCode()),
+        [currentLocale, languages],
+    );
+
+    const displayedLanguages = useMemo(() => {
         if (!languages.length) {
             return [];
         }
 
-        // `LocaleObject` already filters out non-supported locales
-        return getUsedLanguages(languages)
-            .filter((language) => language.code !== currentLocale.toUnderscoreCode())
-            .map(({ code }) => LocaleObject.fromAnyCode(code));
+        return getUsedLanguages(languages).filter(
+            (language) => language.code !== currentLocale.toUnderscoreCode(),
+        );
     }, [currentLocale, languages]);
 
     // Don't show language selector if there are no other locale to choose
-    if (displayedLocales.length < 1) {
+    if (!currentLanguage || displayedLanguages.length < 1) {
         return null;
     }
 
@@ -49,13 +53,14 @@ const LanguagesDropdown: FunctionComponent<Props> = ({
         <li className={navigationItemClassName}>
             <Dropdown
                 icon={IconGlobe}
-                label={getLanguageDisplayName(currentLocale)}
+                label={getLanguageDisplayName(currentLanguage, languages)}
                 className={styles.container}
                 menuClassName={styles.menu}
                 buttonClassName={classNames(buttonClassName, styles.button)}
                 withMobileDisplay
             >
-                {displayedLocales.map((locale) => {
+                {displayedLanguages.map((language) => {
+                    const locale = LocaleObject.fromAnyCode(language.code);
                     const translationLink = hasError ? '/' : getTranslationUrl(locale);
 
                     return (
@@ -70,7 +75,7 @@ const LanguagesDropdown: FunctionComponent<Props> = ({
                             forceRefresh
                             withMobileDisplay
                         >
-                            {getLanguageDisplayName(locale)}
+                            {getLanguageDisplayName(language, languages)}
                         </Dropdown.Item>
                     );
                 })}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^0.3.7",
         "@headlessui/react": "^1.4.1",
-        "@prezly/sdk": "^6.5.0",
+        "@prezly/sdk": "^6.7.0",
         "@prezly/slate-renderer": "^0.2.1",
         "@prezly/slate-types": "^0.2.1",
         "@prezly/themes-intl-messages": "^1.4.0",
@@ -2633,9 +2633,9 @@
       }
     },
     "node_modules/@prezly/sdk": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@prezly/sdk/-/sdk-6.5.0.tgz",
-      "integrity": "sha512-c8FMbeHgJafCaPLPhHHeWwikC7zkxSIouj12u4gYbhA0MfxPQNPy8eyfcm3xS9SU4cauMFcaHP6aHQqvxJdpNQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@prezly/sdk/-/sdk-6.7.0.tgz",
+      "integrity": "sha512-4Xws75kfh/jpmEqLcbDH6zcwcbQEpLF+puzUz9XyOACWNjMxtqyKgz5boFUwzH0i2BlRa+YbnVs+9UKlZSzNYQ==",
       "dependencies": {
         "@prezly/progress-promise": "^1.0.0",
         "@prezly/uploads": "^0.2.1",
@@ -16247,9 +16247,9 @@
       }
     },
     "@prezly/sdk": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@prezly/sdk/-/sdk-6.5.0.tgz",
-      "integrity": "sha512-c8FMbeHgJafCaPLPhHHeWwikC7zkxSIouj12u4gYbhA0MfxPQNPy8eyfcm3xS9SU4cauMFcaHP6aHQqvxJdpNQ==",
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@prezly/sdk/-/sdk-6.7.0.tgz",
+      "integrity": "sha512-4Xws75kfh/jpmEqLcbDH6zcwcbQEpLF+puzUz9XyOACWNjMxtqyKgz5boFUwzH0i2BlRa+YbnVs+9UKlZSzNYQ==",
       "requires": {
         "@prezly/progress-promise": "^1.0.0",
         "@prezly/uploads": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@hcaptcha/react-hcaptcha": "^0.3.7",
     "@headlessui/react": "^1.4.1",
-    "@prezly/sdk": "^6.5.0",
+    "@prezly/sdk": "^6.7.0",
     "@prezly/slate-renderer": "^0.2.1",
     "@prezly/slate-types": "^0.2.1",
     "@prezly/themes-intl-messages": "^1.4.0",


### PR DESCRIPTION
- use `locale.native_name` as display name
- strip culture name if it's the only possible option for a language