### PR TITLE
[TITS-5142] Add support for email media

### DIFF
--- a/components/ContactCard/ContactCard.tsx
+++ b/components/ContactCard/ContactCard.tsx
@@ -25,6 +25,7 @@ function ContactCard({ className, contact, isCompact = false, renderAvatar }: Pr
 
     return (
         <div
+            id={`contact-${contact.uuid}`}
             className={classNames(styles.container, className, {
                 [styles.compact]: isCompact || device.isMobile,
             })}

--- a/components/SlateRenderer/components/Attachment/Attachment.tsx
+++ b/components/SlateRenderer/components/Attachment/Attachment.tsx
@@ -26,7 +26,12 @@ function Attachment({ node }: Props) {
     }
 
     return (
-        <a className={styles.container} href={downloadUrl} onClick={handleClick}>
+        <a
+            id={`attachment-${file.uuid}`}
+            className={styles.container}
+            href={downloadUrl}
+            onClick={handleClick}
+        >
             <div className={styles.icon}>
                 <FileTypeIcon extension={fileExtension} />
             </div>

--- a/modules/analytics/components/Analytics.tsx
+++ b/modules/analytics/components/Analytics.tsx
@@ -67,6 +67,21 @@ function Analytics() {
             trackRef.current(getAssetClickEvent(type), { id, type }, () =>
                 stripUrlParameters('asset_'),
             );
+
+            // Auto-click assest passed in query parameters (used by campaign links)
+            // Pulled from https://github.com/prezly/prezly/blob/9ac32bc15760636ed47eea6fe637d245fa752d32/apps/press/resources/javascripts/prezly.js#L425-L458
+            const delay = type === 'image' || type === 'gallery-image' ? 500 : 0;
+            window.setTimeout(() => {
+                let targetEl = document.getElementById(`${type}-${id}`);
+                if (!targetEl) {
+                    // Fallback to data-attributes marked element
+                    targetEl = document.querySelector(`[data-type='${type}'][data-id='${id}']`);
+                }
+
+                if (targetEl) {
+                    targetEl.click();
+                }
+            }, delay);
         }
     });
 


### PR DESCRIPTION
- Added `id` attributes to the content-renderer nodes overridden by Bea
- Added auto-clicking assets when navigation from email campaigns