### PR TITLE
[MT-4675][DEV-5016] Upgrade @prezly/content-renderer-react-js to v0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^0.3.7",
         "@headlessui/react": "^1.4.1",
-        "@prezly/content-renderer-react-js": "^0.11.1",
+        "@prezly/content-renderer-react-js": "^0.12",
         "@prezly/sdk": "^6.13.0",
         "@prezly/slate-types": "^0.16.0",
         "@prezly/theme-kit-nextjs": "^1.4.0",
@@ -2314,9 +2314,9 @@
       }
     },
     "node_modules/@prezly/content-renderer-react-js": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@prezly/content-renderer-react-js/-/content-renderer-react-js-0.11.1.tgz",
-      "integrity": "sha512-GUP14lvHMK2IMa6YGoaeSkomZcE2/vzHeLk4jAqZdtZ8Sz33+Th2vPXZoOzYPxzGjHCmbCWCK7iDx+XEfNROYw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@prezly/content-renderer-react-js/-/content-renderer-react-js-0.12.0.tgz",
+      "integrity": "sha512-fzakm8VoQWvjEBcSUcS6sS6560OS8p4jdPAsp3ShACywipNNCoYyTF+oQAcSTOwnz4RKHVqiVYg0I5NNEjCpXA==",
       "dependencies": {
         "@prezly/linear-partition": "^1.0.2",
         "@prezly/slate-types": "^0.16.0",
@@ -11311,9 +11311,9 @@
       }
     },
     "@prezly/content-renderer-react-js": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@prezly/content-renderer-react-js/-/content-renderer-react-js-0.11.1.tgz",
-      "integrity": "sha512-GUP14lvHMK2IMa6YGoaeSkomZcE2/vzHeLk4jAqZdtZ8Sz33+Th2vPXZoOzYPxzGjHCmbCWCK7iDx+XEfNROYw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@prezly/content-renderer-react-js/-/content-renderer-react-js-0.12.0.tgz",
+      "integrity": "sha512-fzakm8VoQWvjEBcSUcS6sS6560OS8p4jdPAsp3ShACywipNNCoYyTF+oQAcSTOwnz4RKHVqiVYg0I5NNEjCpXA==",
       "requires": {
         "@prezly/linear-partition": "^1.0.2",
         "@prezly/slate-types": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@hcaptcha/react-hcaptcha": "^0.3.7",
     "@headlessui/react": "^1.4.1",
-    "@prezly/content-renderer-react-js": "^0.11.1",
+    "@prezly/content-renderer-react-js": "^0.12",
     "@prezly/sdk": "^6.13.0",
     "@prezly/slate-types": "^0.16.0",
     "@prezly/theme-kit-nextjs": "^1.4.0",


### PR DESCRIPTION
See https://github.com/prezly/content-renderer-react-js/releases/tag/v0.12.0

## What's Changed
* [MT-4675] Fix - Preserve soft breaks by @e1himself in https://github.com/prezly/content-renderer-react-js/pull/11
* [DEV-5016] Fix - Gallery server-side rendering by @e1himself in https://github.com/prezly/content-renderer-react-js/pull/12
* [DEV-5028] Fix - Gallery image download in original size by @e1himself in https://github.com/prezly/content-renderer-react-js/pull/13
* Fix  - Images popover accessibility (and SSR) improvements by @e1himself in https://github.com/prezly/content-renderer-react-js/pull/14

