### PR TITLE
[DEV-5120][DEV-5082] Added support for new cultures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@prezly/content-renderer-react-js": "^0.13.0",
         "@prezly/sdk": "^6.16.0",
         "@prezly/slate-types": "^0.19.0",
-        "@prezly/theme-kit-nextjs": "^1.4.0",
+        "@prezly/theme-kit-nextjs": "^1.5.0",
         "@prezly/themes-intl-messages": "^1.9.0",
         "@prezly/uploadcare-image": "^0.3.1",
         "@sentry/nextjs": "^6.17.4",
@@ -2432,9 +2432,9 @@
       }
     },
     "node_modules/@prezly/theme-kit-nextjs": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-1.4.0.tgz",
-      "integrity": "sha512-20ONxFYUw54Eo2JQnZEHvBsUVxhaWXKVdnWdWGNZvM8n3bVMBz8qHLTIYDPQWostIoVWt8xtacmqol6FBEWtmA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-1.5.0.tgz",
+      "integrity": "sha512-2J+huq3vmZf8rcuWuITLYN8AWysYr4lnFWIZU4gCIQUN+m7HfYXChKLfGItXxyosarm6kPVbentFLiLn38EVZg==",
       "dependencies": {
         "@prezly/sdk": "^6.11.0",
         "parse-data-url": "^4.0.1"
@@ -11387,9 +11387,9 @@
       }
     },
     "@prezly/theme-kit-nextjs": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-1.4.0.tgz",
-      "integrity": "sha512-20ONxFYUw54Eo2JQnZEHvBsUVxhaWXKVdnWdWGNZvM8n3bVMBz8qHLTIYDPQWostIoVWt8xtacmqol6FBEWtmA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-1.5.0.tgz",
+      "integrity": "sha512-2J+huq3vmZf8rcuWuITLYN8AWysYr4lnFWIZU4gCIQUN+m7HfYXChKLfGItXxyosarm6kPVbentFLiLn38EVZg==",
       "requires": {
         "@prezly/sdk": "^6.11.0",
         "parse-data-url": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@prezly/content-renderer-react-js": "^0.13.0",
     "@prezly/sdk": "^6.16.0",
     "@prezly/slate-types": "^0.19.0",
-    "@prezly/theme-kit-nextjs": "^1.4.0",
+    "@prezly/theme-kit-nextjs": "^1.5.0",
     "@prezly/themes-intl-messages": "^1.9.0",
     "@prezly/uploadcare-image": "^0.3.1",
     "@sentry/nextjs": "^6.17.4",


### PR DESCRIPTION
- `de_BE` and `es-419`, see https://github.com/prezly/theme-kit-nextjs/pull/14