### PR TITLE
[HD-81] Support custom cookie statement

### DIFF
--- a/modules/Layout/CookieConsentBar/CookieConsentBar.module.scss
+++ b/modules/Layout/CookieConsentBar/CookieConsentBar.module.scss
@@ -49,6 +49,12 @@
     @include mobile-only {
         margin-bottom: $spacing-3;
     }
+
+    .custom {
+        p {
+            @include text-small;
+        }
+    }
 }
 
 .notice {

--- a/modules/Layout/CookieConsentBar/CookieConsentBar.module.scss
+++ b/modules/Layout/CookieConsentBar/CookieConsentBar.module.scss
@@ -50,7 +50,7 @@
         margin-bottom: $spacing-3;
     }
 
-    .custom {
+    &.custom {
         p {
             @include text-small;
         }

--- a/modules/Layout/CookieConsentBar/CookieConsentBar.tsx
+++ b/modules/Layout/CookieConsentBar/CookieConsentBar.tsx
@@ -1,7 +1,7 @@
 import { CookieConsentBar as DefaultCookieConsentBar } from '@prezly/analytics-nextjs';
 import { useCompanyInformation } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { useMemo } from 'react';
+import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@/components';
@@ -10,12 +10,6 @@ import styles from './CookieConsentBar.module.scss';
 
 function CookieConsentBar() {
     const { cookie_statement } = useCompanyInformation();
-
-    const cookieStatement = useMemo(() => {
-        const div = document.createElement('div');
-        div.innerHTML = cookie_statement;
-        return div.innerHTML;
-    }, [cookie_statement]);
 
     return (
         <DefaultCookieConsentBar>
@@ -27,18 +21,18 @@ function CookieConsentBar() {
                                 <p className={styles.title}>
                                     <FormattedMessage {...translations.cookieConsent.title} />
                                 </p>
-                                <p className={styles.text}>
-                                    {cookieStatement ? (
-                                        <div
-                                            className={styles.custom}
-                                            dangerouslySetInnerHTML={{ __html: cookieStatement }}
-                                        />
-                                    ) : (
+                                {cookie_statement ? (
+                                    <div
+                                        className={classNames(styles.text, styles.custom)}
+                                        dangerouslySetInnerHTML={{ __html: cookie_statement }}
+                                    />
+                                ) : (
+                                    <p className={styles.text}>
                                         <FormattedMessage
                                             {...translations.cookieConsent.description}
                                         />
-                                    )}
-                                </p>
+                                    </p>
+                                )}
                             </div>
                             <div className={styles.actions}>
                                 <Button

--- a/modules/Layout/CookieConsentBar/CookieConsentBar.tsx
+++ b/modules/Layout/CookieConsentBar/CookieConsentBar.tsx
@@ -1,5 +1,7 @@
 import { CookieConsentBar as DefaultCookieConsentBar } from '@prezly/analytics-nextjs';
+import { useCompanyInformation } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
+import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { Button } from '@/components';
@@ -7,6 +9,14 @@ import { Button } from '@/components';
 import styles from './CookieConsentBar.module.scss';
 
 function CookieConsentBar() {
+    const { cookie_statement } = useCompanyInformation();
+
+    const cookieStatement = useMemo(() => {
+        const div = document.createElement('div');
+        div.innerHTML = cookie_statement;
+        return div.innerHTML;
+    }, [cookie_statement]);
+
     return (
         <DefaultCookieConsentBar>
             {({ onAccept, onReject }) => (
@@ -18,7 +28,16 @@ function CookieConsentBar() {
                                     <FormattedMessage {...translations.cookieConsent.title} />
                                 </p>
                                 <p className={styles.text}>
-                                    <FormattedMessage {...translations.cookieConsent.description} />
+                                    {cookieStatement ? (
+                                        <div
+                                            className={styles.custom}
+                                            dangerouslySetInnerHTML={{ __html: cookieStatement }}
+                                        />
+                                    ) : (
+                                        <FormattedMessage
+                                            {...translations.cookieConsent.description}
+                                        />
+                                    )}
                                 </p>
                             </div>
                             <div className={styles.actions}>

--- a/modules/Layout/CookieConsentBar/CookieConsentBar.tsx
+++ b/modules/Layout/CookieConsentBar/CookieConsentBar.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components';
 import styles from './CookieConsentBar.module.scss';
 
 function CookieConsentBar() {
-    const { cookie_statement } = useCompanyInformation();
+    const { cookie_statement: cookieStatement } = useCompanyInformation();
 
     return (
         <DefaultCookieConsentBar>
@@ -21,10 +21,10 @@ function CookieConsentBar() {
                                 <p className={styles.title}>
                                     <FormattedMessage {...translations.cookieConsent.title} />
                                 </p>
-                                {cookie_statement ? (
+                                {cookieStatement ? (
                                     <div
                                         className={classNames(styles.text, styles.custom)}
-                                        dangerouslySetInnerHTML={{ __html: cookie_statement }}
+                                        dangerouslySetInnerHTML={{ __html: cookieStatement }}
                                     />
                                 ) : (
                                     <p className={styles.text}>


### PR DESCRIPTION
This is something that we forgot to implement but luckily the feature itself is not used by a lot of licenses yet.

When defined in the main app, the returned string contains HTML paragraph(s), so we just need to wrap them in a div.
The editor also supports strong, italic, underline and links.

<img width="548" alt="Screenshot 2022-04-19 at 15 14 19" src="https://user-images.githubusercontent.com/4209081/164013031-7913824b-302d-406d-b735-a2aced1fa9ae.png">
