### PR TITLE
[TF-939] Bea/Greta Bug: Remove hamburguer icon when there is no content in menu

### DIFF
--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from './useDevice';
 export * from './useIsMounted';
 export * from './useThemeSettings';
+export * from './useDisplayedLanguages';

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,4 +1,4 @@
 export * from './useDevice';
+export * from './useDisplayedLanguages';
 export * from './useIsMounted';
 export * from './useThemeSettings';
-export * from './useDisplayedLanguages';

--- a/hooks/useDisplayedLanguages.ts
+++ b/hooks/useDisplayedLanguages.ts
@@ -1,0 +1,16 @@
+import { getUsedLanguages, useCurrentLocale, useLanguages } from '@prezly/theme-kit-nextjs';
+import { useMemo } from 'react';
+
+export function useDisplayedLanguages() {
+    const languages = useLanguages();
+    const currentLocale = useCurrentLocale();
+    return useMemo(() => {
+        if (!languages.length) {
+            return [];
+        }
+
+        return getUsedLanguages(languages).filter(
+            (language) => language.code !== currentLocale.toUnderscoreCode(),
+        );
+    }, [currentLocale, languages]);
+}

--- a/modules/Layout/Header/Header.tsx
+++ b/modules/Layout/Header/Header.tsx
@@ -4,6 +4,7 @@ import {
     useCategories,
     useCompanyInformation,
     useGetLinkLocaleSlug,
+    useLanguages,
     useNewsroom,
 } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
@@ -32,6 +33,7 @@ interface Props {
 function Header({ hasError }: Props) {
     const { newsroom_logo, display_name, public_galleries_number } = useNewsroom();
     const categories = useCategories();
+    const languages = useLanguages();
     const { name } = useCompanyInformation();
     const getLinkLocaleSlug = useGetLinkLocaleSlug();
     const { formatMessage } = useIntl();
@@ -43,6 +45,8 @@ function Header({ hasError }: Props) {
     const headerRef = useRef<HTMLElement>(null);
 
     const IS_SEARCH_ENABLED = Boolean(ALGOLIA_API_KEY);
+
+    const shouldShowMenu = categories.length > 0 || languages.length > 0 || public_galleries_number > 0; //prettier-ignore
 
     function alignMobileHeader() {
         if (!isMobile) {
@@ -134,18 +138,20 @@ function Header({ hasError }: Props) {
                             />
                         )}
 
-                        <Button
-                            variation="navigation"
-                            icon={isMenuOpen ? IconClose : IconMenu}
-                            className={classNames(styles.navigationToggle, {
-                                [styles.hidden]: isSearchWidgetShown,
-                            })}
-                            onClick={toggleMenu}
-                            aria-expanded={isMenuOpen}
-                            aria-controls="menu"
-                            title={formatMessage(translations.misc.toggleMobileNavigation)}
-                            aria-label={formatMessage(translations.misc.toggleMobileNavigation)}
-                        />
+                        {shouldShowMenu && (
+                            <Button
+                                variation="navigation"
+                                icon={isMenuOpen ? IconClose : IconMenu}
+                                className={classNames(styles.navigationToggle, {
+                                    [styles.hidden]: isSearchWidgetShown,
+                                })}
+                                onClick={toggleMenu}
+                                aria-expanded={isMenuOpen}
+                                aria-controls="menu"
+                                title={formatMessage(translations.misc.toggleMobileNavigation)}
+                                aria-label={formatMessage(translations.misc.toggleMobileNavigation)}
+                            />
+                        )}
 
                         <div
                             className={classNames(styles.navigation, { [styles.open]: isMenuOpen })}

--- a/modules/Layout/Header/Header.tsx
+++ b/modules/Layout/Header/Header.tsx
@@ -17,7 +17,7 @@ import type { MouseEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { useDevice } from '@/hooks';
+import { useDevice, useDisplayedLanguages } from '@/hooks';
 
 import CategoriesDropdown from './CategoriesDropdown';
 import LanguagesDropdown from './LanguagesDropdown';
@@ -33,7 +33,7 @@ interface Props {
 function Header({ hasError }: Props) {
     const { newsroom_logo, display_name, public_galleries_number } = useNewsroom();
     const categories = useCategories();
-    const languages = useLanguages();
+    const displayedLanguages = useDisplayedLanguages();
     const { name } = useCompanyInformation();
     const getLinkLocaleSlug = useGetLinkLocaleSlug();
     const { formatMessage } = useIntl();
@@ -47,7 +47,7 @@ function Header({ hasError }: Props) {
     const IS_SEARCH_ENABLED = Boolean(ALGOLIA_API_KEY);
 
     const shouldShowMenu =
-        categories.length > 0 || languages.length > 0 || public_galleries_number > 0;
+        categories.length > 0 || displayedLanguages.length > 0 || public_galleries_number > 0;
 
     function alignMobileHeader() {
         if (!isMobile) {

--- a/modules/Layout/Header/Header.tsx
+++ b/modules/Layout/Header/Header.tsx
@@ -46,7 +46,8 @@ function Header({ hasError }: Props) {
 
     const IS_SEARCH_ENABLED = Boolean(ALGOLIA_API_KEY);
 
-    const shouldShowMenu = categories.length > 0 || languages.length > 0 || public_galleries_number > 0; //prettier-ignore
+    const shouldShowMenu =
+        categories.length > 0 || languages.length > 0 || public_galleries_number > 0;
 
     function alignMobileHeader() {
         if (!isMobile) {

--- a/modules/Layout/Header/Header.tsx
+++ b/modules/Layout/Header/Header.tsx
@@ -4,7 +4,6 @@ import {
     useCategories,
     useCompanyInformation,
     useGetLinkLocaleSlug,
-    useLanguages,
     useNewsroom,
 } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';

--- a/modules/Layout/Header/LanguagesDropdown/LanguagesDropdown.tsx
+++ b/modules/Layout/Header/LanguagesDropdown/LanguagesDropdown.tsx
@@ -11,9 +11,8 @@ import {
 import classNames from 'classnames';
 import { useMemo } from 'react';
 
-import { useDisplayedLanguages } from '@/hooks';
-
 import { Dropdown } from '@/components';
+import { useDisplayedLanguages } from '@/hooks';
 
 import styles from './LanguagesDropdown.module.scss';
 

--- a/modules/Layout/Header/LanguagesDropdown/LanguagesDropdown.tsx
+++ b/modules/Layout/Header/LanguagesDropdown/LanguagesDropdown.tsx
@@ -1,7 +1,6 @@
 import { IconGlobe } from '@prezly/icons';
 import {
     getLanguageDisplayName,
-    getUsedLanguages,
     LocaleObject,
     useCurrentLocale,
     useCurrentStory,
@@ -11,6 +10,8 @@ import {
 } from '@prezly/theme-kit-nextjs';
 import classNames from 'classnames';
 import { useMemo } from 'react';
+
+import { useDisplayedLanguages } from '@/hooks';
 
 import { Dropdown } from '@/components';
 
@@ -34,15 +35,7 @@ function LanguagesDropdown({ buttonClassName, navigationItemClassName, hasError 
         [currentLocale, languages],
     );
 
-    const displayedLanguages = useMemo(() => {
-        if (!languages.length) {
-            return [];
-        }
-
-        return getUsedLanguages(languages).filter(
-            (language) => language.code !== currentLocale.toUnderscoreCode(),
-        );
-    }, [currentLocale, languages]);
+    const displayedLanguages = useDisplayedLanguages();
 
     // Don't show language selector if there are no other locale to choose
     if (!currentLanguage || displayedLanguages.length < 1) {


### PR DESCRIPTION
As mentioned in the ticket, when a user doesn't use categories or languages we should hide the mobile menu toggler.
One more case to notice is when the user has a gallery but no images in it, so I tried to handle that case as well.