### PR TITLE
[TF-945] Bea improvements: Smaller Story Cards

### DIFF
--- a/components/StoryCards/StoryCard.module.scss
+++ b/components/StoryCards/StoryCard.module.scss
@@ -132,12 +132,18 @@ $small-card-image-size: 230px;
             @include heading-3;
             @include ensure-max-text-height(3, $line-height-m);
 
-            margin-bottom: $spacing-1;
+            margin-bottom: 0;
         }
 
         @include desktop-up {
             @include paragraph;
             @include ensure-max-text-height(3, $line-height-s);
+        }
+    }
+
+    .date {
+        @include desktop-up {
+            margin-top: $spacing-1;
         }
     }
 

--- a/components/StoryCards/StoryCard.module.scss
+++ b/components/StoryCards/StoryCard.module.scss
@@ -106,7 +106,7 @@ $small-card-image-size: 230px;
     @include text-label;
 
     margin: 0;
-    color: $color-base-500;
+    color: $color-base-600;
 }
 
 .small {
@@ -141,10 +141,16 @@ $small-card-image-size: 230px;
         }
     }
 
-    .subtitle {
-        @include tablet-up {
-            @include paragraph;
-            @include ensure-max-text-height(2, $line-height-s);
+    .title.noCategories,
+    .title.noDate {
+        @include desktop-up {
+            @include ensure-max-text-height(4, $line-height-s);
+        }
+    }
+
+    .title.noDateAndCategories {
+        @include desktop-up {
+            @include ensure-max-text-height(5, $line-height-s);
         }
     }
 }

--- a/components/StoryCards/StoryCard.tsx
+++ b/components/StoryCards/StoryCard.tsx
@@ -2,7 +2,7 @@ import { StoryPublicationDate } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import Link from 'next/link';
 
-import { useThemeSettings } from '@/hooks';
+import { useDevice, useThemeSettings } from '@/hooks';
 import type { StoryWithImage } from 'types';
 
 import CategoriesList from '../CategoriesList';
@@ -18,9 +18,10 @@ type Props = {
 function StoryCard({ story, size = 'small' }: Props) {
     const { categories, title, subtitle } = story;
     const { showDate, showSubtitle } = useThemeSettings();
-
+    const { isTablet } = useDevice();
+    const hasCategories = categories.length > 0;
     const HeadingTag = size === 'small' ? 'h3' : 'h2';
-
+    const shouldShowSubtitle = isTablet ? true : size !== 'small';
     return (
         <div
             className={classNames(styles.container, {
@@ -39,7 +40,7 @@ function StoryCard({ story, size = 'small' }: Props) {
                 </a>
             </Link>
             <div className={styles.content}>
-                {categories.length > 0 && (
+                {hasCategories && (
                     <div className={styles.categories}>
                         <CategoriesList
                             categories={categories}
@@ -48,13 +49,21 @@ function StoryCard({ story, size = 'small' }: Props) {
                         />
                     </div>
                 )}
-                <HeadingTag className={styles.title}>
+
+                <HeadingTag
+                    className={classNames(
+                        styles.title,
+                        !hasCategories && styles.noCategories,
+                        !showDate && styles.noDate,
+                        !hasCategories && !showDate && styles.noDateAndCategories,
+                    )}
+                >
                     <Link href={`/${story.slug}`} locale={false} passHref>
                         <a className={styles.titleLink}>{title}</a>
                     </Link>
                 </HeadingTag>
 
-                {subtitle && showSubtitle && (
+                {subtitle && showSubtitle && shouldShowSubtitle && (
                     <p className={styles.subtitle}>
                         <Link href={`/${story.slug}`} locale={false} passHref>
                             <a className={styles.subtitleLink}>{subtitle}</a>

--- a/components/StoryCards/StoryCard.tsx
+++ b/components/StoryCards/StoryCard.tsx
@@ -51,12 +51,11 @@ function StoryCard({ story, size = 'small' }: Props) {
                 )}
 
                 <HeadingTag
-                    className={classNames(
-                        styles.title,
-                        !hasCategories && styles.noCategories,
-                        !showDate && styles.noDate,
-                        !hasCategories && !showDate && styles.noDateAndCategories,
-                    )}
+                    className={classNames(styles.title, {
+                        [styles.noCategories]: !hasCategories,
+                        [styles.noDate]: !showDate,
+                        [styles.noDateAndCategories]: !hasCategories && !showDate,
+                    })}
                 >
                     <Link href={`/${story.slug}`} locale={false} passHref>
                         <a className={styles.titleLink}>{title}</a>

--- a/styles/mixins/_images.scss
+++ b/styles/mixins/_images.scss
@@ -60,10 +60,6 @@
 @mixin small-card-aspect-ratio {
     @include base-card-aspect-ratio;
 
-    @include tablet-up {
-        aspect-ratio: 1 / 1;
-    }
-
     @supports not (aspect-ratio: auto) {
         @include tablet-up {
             height: 320px;


### PR DESCRIPTION
- [x] The card images aspect ratio changed to 135:92 (same as main card)
- [x] Remove subtitles for this card type
- [x] “Title section” bottom/top-padding removed
- [x] Date color changed to $neutral-600
- [x] New truncation behavior