### PR TITLE
[TF-948] Use only one type of story card in tablet screens

### DIFF
--- a/components/StoryCards/StoryCard.module.scss
+++ b/components/StoryCards/StoryCard.module.scss
@@ -3,10 +3,6 @@ $small-card-image-size: 230px;
 .container {
     position: relative;
 
-    &:not(:last-of-type) {
-        margin-bottom: $spacing-6;
-    }
-
     /* stylelint-disable-next-line order/order */
     @include desktop-up {
         &:not(:last-of-type) {
@@ -54,7 +50,11 @@ $small-card-image-size: 230px;
 }
 
 .content {
-    padding: $spacing-5 0;
+    padding-top: $spacing-4 - $spacing-half; // 20px
+
+    @include desktop-up {
+        padding: ($spacing-4 - $spacing-half) 0; // 20px 0
+    }
 }
 
 .categories {
@@ -110,7 +110,7 @@ $small-card-image-size: 230px;
 }
 
 .small {
-    @include tablet-up {
+    @include desktop-up {
         display: grid;
         grid-template-columns: $small-card-image-size auto;
         gap: 0 $spacing-4;
@@ -122,13 +122,13 @@ $small-card-image-size: 230px;
     }
 
     .content {
-        @include tablet-up {
+        @include desktop-up {
             padding: 0;
         }
     }
 
     .title {
-        @include tablet-up {
+        @include desktop-up {
             @include heading-3;
             @include ensure-max-text-height(3, $line-height-m);
 
@@ -161,20 +161,6 @@ $small-card-image-size: 230px;
     }
 }
 
-.medium,
-.big {
-    @include tablet-only {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        align-items: center;
-        gap: 0 $spacing-4;
-
-        .content {
-            padding: 0;
-        }
-    }
-}
-
 .medium {
     .imageWrapper {
         @include medium-card-aspect-ratio;
@@ -184,12 +170,6 @@ $small-card-image-size: 230px;
 .big {
     .imageWrapper {
         @include big-card-aspect-ratio;
-    }
-}
-
-@include tablet-only {
-    .medium + .small {
-        margin-top: $spacing-9;
     }
 }
 

--- a/modules/InfiniteStories/StoriesList.module.scss
+++ b/modules/InfiniteStories/StoriesList.module.scss
@@ -7,6 +7,18 @@
 }
 
 .storiesContainer {
+    @include mobile-only {
+        display: grid;
+        grid-template-columns: repeat(1, 1fr);
+        row-gap: $spacing-6;
+    }
+
+    @include tablet-only {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: $spacing-7 $spacing-6;
+    }
+
     @include desktop-up {
         display: grid;
         grid-template-columns: repeat(6, 1fr);

--- a/styles/mixins/_images.scss
+++ b/styles/mixins/_images.scss
@@ -24,15 +24,7 @@
 @mixin big-card-aspect-ratio {
     @include base-card-aspect-ratio;
 
-    @include tablet-only {
-        aspect-ratio: 1 / 1;
-    }
-
     @supports not (aspect-ratio: auto) {
-        @include tablet-up {
-            height: 320px;
-        }
-
         @include desktop-up {
             height: 340px;
         }
@@ -42,15 +34,7 @@
 @mixin medium-card-aspect-ratio {
     @include base-card-aspect-ratio;
 
-    @include tablet-up {
-        aspect-ratio: 1 / 1;
-    }
-
     @supports not (aspect-ratio: auto) {
-        @include tablet-up {
-            height: 320px;
-        }
-
         @include desktop-up {
             height: 340px;
         }

--- a/styles/variables/_spacing.scss
+++ b/styles/variables/_spacing.scss
@@ -14,8 +14,8 @@ $spacing-12: 32rem; // 512px
 
 $grid-gutter-mobile: 1.25rem; // 20px
 $grid-spacing-mobile: 1.25rem; // 20px
-$grid-gutter-tablet: 2.5rem; // 40px
-$grid-spacing-tablet: 2.5rem; // 40px
+$grid-gutter-tablet: 2rem; // 32px
+$grid-spacing-tablet: 2rem; // 32px
 $grid-gutter-desktop: 2.5rem; // 40px
 $grid-spacing-desktop: 2.5rem; // 40px
 $grid-spacing-desktop-large: 5rem; // 80px


### PR DESCRIPTION
- Decreased gutter/spacing in tablet to `32px` [according to new design](https://www.figma.com/file/j0ty2jW7wHD4bFcOyWn39a/Working-%F0%9F%9A%A7-Bea-Theme?node-id=745%3A27072)
- Use one type of story card on tablet screens (The vertical variant)
- Adjust spacings to make it closer to the design
- Set the same aspect ratio for images in all types of story cards

I guess it makes more sense to follow `vertical` and `horizontal` variants for story cards instead of `big` | `medium` | `small` sizes. However, that refactor may change lots of stuff but that's something we can consider to simplify CSS.