### PR TITLE
[TF-991] fixed broken categories logic bug

### DIFF
--- a/components/CategoriesList/CategoriesList.module.scss
+++ b/components/CategoriesList/CategoriesList.module.scss
@@ -1,5 +1,6 @@
 .moreCategories {
     @include text-label;
+
     color: var(--prezly-accent-color);
     font-weight: $font-weight-bold;
 

--- a/components/CategoriesList/CategoriesList.module.scss
+++ b/components/CategoriesList/CategoriesList.module.scss
@@ -1,8 +1,10 @@
 .moreCategories {
     @include text-label;
-
     color: var(--prezly-accent-color);
     font-weight: $font-weight-bold;
+
+    // Added this since the link is not clickable regargdless of how many items it has.
+    display: none;
 }
 
 // TODO: This just replicates styles from the CategoryLink component


### PR DESCRIPTION
I added display to be none when static condition is true, since it is not able to be clicked either way.