### PR TITLE
[TF-1038] Unusual vertical line & space appearing before Quoted Text block

### DIFF
--- a/components/RichText/styles.module.scss
+++ b/components/RichText/styles.module.scss
@@ -123,13 +123,18 @@
 .htmlContent blockquote {
     @include border-radius-m;
 
+    position: relative;
     margin: $spacing-6 auto;
-    padding: $spacing-4;
+    padding: $spacing-4 $spacing-6;
     background: $color-base-50;
 
     &::before {
         content: "";
         border-left: 2px solid $color-base-400;
-        padding-left: $spacing-3;
+        padding-left: $spacing-4;
+        position: absolute;
+        top: $spacing-3;
+        bottom: $spacing-3;
+        left: $spacing-3;
     }
 }


### PR DESCRIPTION
How it looks now, aligned with how quotes in general looks
![image](https://user-images.githubusercontent.com/43710420/181227174-6c9b3766-ed04-4303-8107-ed7f9ab4ca2f.png)
