### PR TITLE
[CARE-1215] Get rid of `@prezly/themes-ui-components`

### DIFF
--- a/components/CategoriesList/CategoriesList.module.scss
+++ b/components/CategoriesList/CategoriesList.module.scss
@@ -5,36 +5,20 @@
     font-weight: $font-weight-bold;
 }
 
+.categoryLink {
+    &:hover,
+    &:focus,
+    &:active {
+        text-decoration: none;
+    }
+}
+
 // TODO: This just replicates styles from the CategoryLink component
 .moreCategoriesLink {
     @include link-primary;
 
     text-decoration: none;
     cursor: pointer;
-
-    &:hover,
-    &:focus {
-        span {
-            text-decoration: underline;
-        }
-    }
-}
-
-.categoryLink {
-    &:not(:last-child) {
-        &::after {
-            content: ",";
-            margin-right: $spacing-half;
-        }
-    }
-
-    &:hover {
-        text-decoration: none;
-    }
-
-    &:hover span {
-        text-decoration: none;
-    }
 }
 
 .categoriesList {

--- a/components/CategoriesList/CategoriesList.tsx
+++ b/components/CategoriesList/CategoriesList.tsx
@@ -1,9 +1,10 @@
 import type { Category } from '@prezly/sdk';
 import type { AlgoliaCategoryRef } from '@prezly/theme-kit-nextjs';
 import { getLocalizedCategoryData, useCurrentLocale } from '@prezly/theme-kit-nextjs';
-import { CategoryLink } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import { useMemo, useState } from 'react';
+
+import { CategoryLink } from '../CategoryLink';
 
 import styles from './CategoriesList.module.scss';
 

--- a/components/CategoryLink/CategoryLink.module.scss
+++ b/components/CategoryLink/CategoryLink.module.scss
@@ -1,0 +1,18 @@
+@import "variables";
+@import "mixins";
+
+.link {
+    @include text-label;
+    @include link-primary;
+
+    font-weight: $font-weight-bold;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:not(:last-child) {
+        &::after {
+            content: ",";
+            margin-right: $spacing-half;
+        }
+    }
+}

--- a/components/CategoryLink/CategoryLink.tsx
+++ b/components/CategoryLink/CategoryLink.tsx
@@ -1,0 +1,36 @@
+import type { Category } from '@prezly/sdk';
+import type { AlgoliaCategoryRef } from '@prezly/theme-kit-nextjs';
+import {
+    getCategoryUrl,
+    getLocalizedCategoryData,
+    useCurrentLocale,
+    useGetLinkLocaleSlug,
+} from '@prezly/theme-kit-nextjs';
+import classNames from 'classnames';
+import Link from 'next/link';
+
+import styles from './CategoryLink.module.scss';
+
+type Props = {
+    category: Category | AlgoliaCategoryRef;
+    className?: string;
+};
+
+export function CategoryLink({ category, className }: Props) {
+    const currentLocale = useCurrentLocale();
+    const { name } = getLocalizedCategoryData(category, currentLocale);
+    const getLinkLocaleSlug = useGetLinkLocaleSlug();
+
+    return (
+        <Link
+            href={getCategoryUrl(category, currentLocale)}
+            locale={getLinkLocaleSlug()}
+            passHref
+            legacyBehavior
+        >
+            <a className={classNames(styles.link, className)}>
+                <span>{name}</span>
+            </a>
+        </Link>
+    );
+}

--- a/components/CategoryLink/index.ts
+++ b/components/CategoryLink/index.ts
@@ -1,0 +1,1 @@
+export { CategoryLink } from './CategoryLink';

--- a/components/Dropdown/Dropdown.tsx
+++ b/components/Dropdown/Dropdown.tsx
@@ -1,11 +1,11 @@
 import { Menu, Transition } from '@headlessui/react';
 import type { IconComponentType } from '@prezly/icons';
 import { IconCaret } from '@prezly/icons';
-import { Button } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import type { PropsWithChildren, ReactNode } from 'react';
 import { Fragment } from 'react';
 
+import { Button } from '@/ui';
 import { makeComposableComponent } from '@/utils';
 
 import Item from './DropdownItem';

--- a/components/NotificationsBar/LinkedText.tsx
+++ b/components/NotificationsBar/LinkedText.tsx
@@ -1,0 +1,53 @@
+import { type ReactElement } from 'react';
+
+interface Props {
+    links: Link[];
+    children: string;
+}
+
+interface Link {
+    name: string;
+    target: string;
+}
+
+/**
+ * Replace text marked with "[...]" with the anchor elements.
+ *
+ * Example:
+ *
+ *   description: "Visit [our website] to start using the most awesome PR software"
+ *   actions:     { name: "our website", target: "https://www.prezly.com/" }
+ *
+ * Result:
+ *
+ *   Visit <a href="https://www.prezly.com/">our website</a> to start using the most awesome PR software.
+ *
+ */
+export function LinkedText({ children: text, links }: Props) {
+    let parts: (ReactElement | string)[] = [text];
+
+    links.forEach(({ target, name }) => {
+        parts = parts.flatMap((part) => {
+            const replace = `[${name}]`;
+            if (typeof part !== 'string' || !part.includes(replace)) {
+                return part;
+            }
+            return part.split(replace).flatMap((value, index) => {
+                if (index === 0) return [value];
+                return [
+                    <a
+                        key={`${target}:${name}`}
+                        href={target}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        {name}
+                    </a>,
+                    value,
+                ];
+            });
+        });
+    });
+
+    return <>{parts}</>;
+}

--- a/components/NotificationsBar/NotificationsBar.module.scss
+++ b/components/NotificationsBar/NotificationsBar.module.scss
@@ -1,0 +1,37 @@
+@import "variables";
+@import "mixins";
+
+.container {
+    height: 40px;
+}
+
+.banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    min-height: 40px;
+    padding: $spacing-1;
+    vertical-align: middle;
+    color: $color-base-white;
+    background-color: $color-error-shade;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+}
+
+.content {
+    line-height: 1.4;
+    text-align: center;
+
+    a {
+        &,
+        &:hover,
+        &:active,
+        &:visited,
+        &:focus {
+            color: inherit;
+        }
+    }
+}

--- a/components/NotificationsBar/NotificationsBar.tsx
+++ b/components/NotificationsBar/NotificationsBar.tsx
@@ -1,0 +1,52 @@
+import type { Notification } from '@prezly/sdk';
+import classNames from 'classnames';
+import type { HTMLAttributes } from 'react';
+import { useRef, useState } from 'react';
+
+import { useOnResize } from './lib';
+import { LinkedText } from './LinkedText';
+
+import styles from './NotificationsBar.module.scss';
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+    notifications: Notification[];
+}
+
+function Notifications({ className, notifications, style, ...attributes }: Props) {
+    const [height, setHeight] = useState<number>();
+    const container = useRef<HTMLDivElement>(null);
+    const banner = useRef<HTMLDivElement>(null);
+
+    useOnResize(() => {
+        setHeight(banner.current?.getBoundingClientRect().height);
+    });
+
+    return (
+        <div
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...attributes}
+            className={classNames(styles.container, className)}
+            ref={container}
+            style={{ ...style, height }}
+        >
+            <div className={styles.banner} ref={banner}>
+                <div className={styles.content}>
+                    {notifications.map(({ id, title, description, actions }) => (
+                        <LinkedText key={id} links={actions}>
+                            {`${title} ${description}`}
+                        </LinkedText>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export function NotificationsBar({ notifications, ...props }: Props) {
+    if (notifications.length === 0) {
+        return null;
+    }
+
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <Notifications {...props} notifications={notifications} />;
+}

--- a/components/NotificationsBar/index.ts
+++ b/components/NotificationsBar/index.ts
@@ -1,0 +1,1 @@
+export { NotificationsBar } from './NotificationsBar';

--- a/components/NotificationsBar/lib.ts
+++ b/components/NotificationsBar/lib.ts
@@ -1,0 +1,25 @@
+import { type RefObject, useEffect, useRef } from 'react';
+
+function useLatestValue<T>(value: T): RefObject<T> {
+    const ref = useRef<T>(value);
+    ref.current = value;
+    return ref;
+}
+
+export function useOnResize(onResize: () => void) {
+    const callback = useLatestValue(onResize);
+
+    useEffect(() => {
+        callback.current?.();
+
+        function handleResize() {
+            callback.current?.();
+        }
+
+        window.addEventListener('resize', handleResize);
+
+        return () => {
+            window.removeEventListener('resize', handleResize);
+        };
+    }, [callback]);
+}

--- a/components/SlateRenderer/components/Attachment/FileTypeIcon.tsx
+++ b/components/SlateRenderer/components/Attachment/FileTypeIcon.tsx
@@ -73,7 +73,6 @@ function getIconComponentFromExtension(extension?: string) {
     }
 }
 
-// TODO: Move to `@prezly/icons` or `@prezly/themes-ui-components`
 function FileTypeIcon({ extension, className }: Props) {
     const IconComponent = getIconComponentFromExtension(extension);
     return <IconComponent className={className} />;

--- a/components/SlateRenderer/components/Variable.tsx
+++ b/components/SlateRenderer/components/Variable.tsx
@@ -1,6 +1,7 @@
 import type { VariableNode } from '@prezly/story-content-format';
 import { useCurrentStory } from '@prezly/theme-kit-nextjs';
-import { StoryPublicationDate } from '@prezly/themes-ui-components';
+
+import { StoryPublicationDate } from '@/components';
 
 interface Props {
     node: VariableNode;

--- a/components/SocialMedia/SocialMedia.module.scss
+++ b/components/SocialMedia/SocialMedia.module.scss
@@ -1,0 +1,26 @@
+@import "variables";
+
+.container {
+    display: flex;
+}
+
+.link {
+    display: block;
+    color: $color-base-white;
+
+    &:hover,
+    &:focus {
+        color: $color-base-300;
+    }
+
+    & + & {
+        margin-left: $spacing-3;
+    }
+}
+
+.icon {
+    $size: 1.5rem;
+
+    width: $size;
+    height: $size;
+}

--- a/components/SocialMedia/SocialMedia.tsx
+++ b/components/SocialMedia/SocialMedia.tsx
@@ -1,0 +1,114 @@
+import {
+    IconFacebook,
+    IconInstagram,
+    IconLinkedin,
+    IconPinterest,
+    IconTikTok,
+    IconTwitter,
+    IconYoutube,
+} from '@prezly/icons';
+import type { NewsroomCompanyInformation } from '@prezly/sdk';
+import classNames from 'classnames';
+
+import { getSocialLinks } from './utils';
+
+import styles from './SocialMedia.module.scss';
+
+type Props = {
+    className?: string;
+    companyInformation: NewsroomCompanyInformation;
+};
+
+export function SocialMedia({ className, companyInformation }: Props) {
+    const { facebook, instagram, linkedin, pinterest, tiktok, twitter, youtube } =
+        getSocialLinks(companyInformation);
+
+    return (
+        <div className={classNames(className, styles.container)}>
+            {facebook && (
+                <a
+                    href={facebook}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Facebook"
+                    aria-label="Facebook"
+                    className={styles.link}
+                >
+                    <IconFacebook width={24} height={24} className={styles.icon} />
+                </a>
+            )}
+            {instagram && (
+                <a
+                    href={instagram}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Instagram"
+                    aria-label="Instagram"
+                    className={styles.link}
+                >
+                    <IconInstagram width={24} height={24} className={styles.icon} />
+                </a>
+            )}
+            {linkedin && (
+                <a
+                    href={linkedin}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="LinkedIn"
+                    aria-label="LinkedIn"
+                    className={styles.link}
+                >
+                    <IconLinkedin width={24} height={24} className={styles.icon} />
+                </a>
+            )}
+            {pinterest && (
+                <a
+                    href={pinterest}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Pinterest"
+                    aria-label="Pinterest"
+                    className={styles.link}
+                >
+                    <IconPinterest width={24} height={24} className={styles.icon} />
+                </a>
+            )}
+            {tiktok && (
+                <a
+                    href={tiktok}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="TikTok"
+                    aria-label="TikTok"
+                    className={styles.link}
+                >
+                    <IconTikTok width={24} height={24} className={styles.icon} />
+                </a>
+            )}
+            {twitter && (
+                <a
+                    href={twitter}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Twitter"
+                    aria-label="Twitter"
+                    className={styles.link}
+                >
+                    <IconTwitter width={24} height={24} className={styles.icon} />
+                </a>
+            )}
+            {youtube && (
+                <a
+                    href={youtube}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Youtube"
+                    aria-label="Youtube"
+                    className={styles.link}
+                >
+                    <IconYoutube width={24} height={24} className={styles.icon} />
+                </a>
+            )}
+        </div>
+    );
+}

--- a/components/SocialMedia/SocialShareButton.module.scss
+++ b/components/SocialMedia/SocialShareButton.module.scss
@@ -1,0 +1,8 @@
+.button {
+    background-color: transparent;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+}

--- a/components/SocialMedia/SocialShareButton.tsx
+++ b/components/SocialMedia/SocialShareButton.tsx
@@ -1,0 +1,41 @@
+import classNames from 'classnames';
+import type { PropsWithChildren } from 'react';
+
+import type { ShareableSocialNetwork } from './types';
+import { getSocialShareUrl } from './utils';
+
+import styles from './SocialShareButton.module.scss';
+
+interface ShareButtonProps {
+    network: ShareableSocialNetwork;
+    url: string;
+    className?: string;
+}
+
+export function SocialShareButton({
+    network,
+    url,
+    className,
+    children,
+}: PropsWithChildren<ShareButtonProps>) {
+    const shareUrl = getSocialShareUrl(network, url);
+
+    if (!shareUrl) {
+        return null;
+    }
+
+    function handleClick() {
+        window.open(shareUrl, '_blank');
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={handleClick}
+            aria-label={network}
+            className={classNames(styles.button, className)}
+        >
+            {children}
+        </button>
+    );
+}

--- a/components/SocialMedia/index.ts
+++ b/components/SocialMedia/index.ts
@@ -1,0 +1,2 @@
+export { SocialMedia } from './SocialMedia';
+export { SocialShareButton } from './SocialShareButton';

--- a/components/SocialMedia/types.ts
+++ b/components/SocialMedia/types.ts
@@ -1,0 +1,13 @@
+export type SocialNetwork =
+    | 'facebook'
+    | 'instagram'
+    | 'linkedin'
+    | 'pinterest'
+    | 'tiktok'
+    | 'twitter'
+    | 'youtube';
+
+/**
+ * Instagram, TikTok and YouTube don't provide URL sharing to their networks as of July 2022
+ */
+export type ShareableSocialNetwork = Exclude<SocialNetwork, 'instagram' | 'tiktok' | 'youtube'>;

--- a/components/SocialMedia/utils.ts
+++ b/components/SocialMedia/utils.ts
@@ -1,0 +1,72 @@
+import type { NewsroomCompanyInformation } from '@prezly/sdk';
+
+import type { ShareableSocialNetwork, SocialNetwork } from './types';
+
+function prependAtToUsername(username: string): string {
+    if (username.startsWith('@')) {
+        return username;
+    }
+
+    return `@${username}`;
+}
+
+function getSocialLink(socialNetwork: SocialNetwork, url: string | null): string | null {
+    if (!url || url.startsWith('http') || url.startsWith('www')) {
+        return url;
+    }
+
+    switch (socialNetwork) {
+        case 'facebook':
+            return `https://facebook.com/${url}`;
+        case 'instagram':
+            return `https://instagram.com/${url}/`;
+        case 'linkedin':
+            return `https://linkedin.com/in/${url}`;
+        case 'pinterest':
+            return `https://pinterest.com/${url}`;
+        case 'tiktok':
+            return `https://tiktok.com/${prependAtToUsername(url)}`;
+        case 'twitter':
+            return `https://twitter.com/${url}`;
+        case 'youtube':
+            return `https://youtube.com/${url}`;
+        default:
+            return null;
+    }
+}
+
+export function getSocialLinks(companyInformation: NewsroomCompanyInformation) {
+    const { facebook, instagram, linkedin, pinterest, tiktok, twitter, youtube } =
+        companyInformation;
+
+    return {
+        facebook: getSocialLink('facebook', facebook),
+        instagram: getSocialLink('instagram', instagram),
+        linkedin: getSocialLink('linkedin', linkedin),
+        pinterest: getSocialLink('pinterest', pinterest),
+        tiktok: getSocialLink('tiktok', tiktok),
+        twitter: getSocialLink('twitter', twitter),
+        youtube: getSocialLink('youtube', youtube),
+    };
+}
+
+export function getSocialShareUrl(network: ShareableSocialNetwork, url: string) {
+    const encodedUrl = encodeURI(url);
+
+    if (!encodedUrl) {
+        return undefined;
+    }
+
+    switch (network) {
+        case 'facebook':
+            return `https://www.facebook.com/sharer.php?u=${encodedUrl}`;
+        case 'linkedin':
+            return `https://www.linkedin.com/shareArticle?url=${encodedUrl}`;
+        case 'pinterest':
+            return `http://pinterest.com/pin/create/button/?url=${encodedUrl}`;
+        case 'twitter':
+            return `https://twitter.com/intent/tweet?url=${encodedUrl}`;
+        default:
+            return undefined;
+    }
+}

--- a/components/StoryCards/HighlightedStoryCard.tsx
+++ b/components/StoryCards/HighlightedStoryCard.tsx
@@ -1,7 +1,7 @@
-import { StoryPublicationDate } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import Link from 'next/link';
 
+import { StoryPublicationDate } from '@/components';
 import { useThemeSettings } from '@/hooks';
 import type { StoryWithImage } from 'types';
 

--- a/components/StoryCards/HighlightedStoryCard.tsx
+++ b/components/StoryCards/HighlightedStoryCard.tsx
@@ -1,12 +1,12 @@
 import classNames from 'classnames';
 import Link from 'next/link';
 
-import { StoryPublicationDate } from '@/components';
 import { useThemeSettings } from '@/hooks';
 import type { StoryWithImage } from 'types';
 
 import CategoriesList from '../CategoriesList';
 import StoryImage from '../StoryImage';
+import { StoryPublicationDate } from '../StoryPublicationDate';
 
 import styles from './HighlightedStoryCard.module.scss';
 

--- a/components/StoryCards/StoryCard.tsx
+++ b/components/StoryCards/StoryCard.tsx
@@ -1,12 +1,12 @@
 import classNames from 'classnames';
 import Link from 'next/link';
 
-import { StoryPublicationDate } from '@/components';
 import { useDevice, useThemeSettings } from '@/hooks';
 import type { StoryWithImage } from 'types';
 
 import CategoriesList from '../CategoriesList';
 import StoryImage from '../StoryImage';
+import { StoryPublicationDate } from '../StoryPublicationDate';
 
 import styles from './StoryCard.module.scss';
 

--- a/components/StoryCards/StoryCard.tsx
+++ b/components/StoryCards/StoryCard.tsx
@@ -1,7 +1,7 @@
-import { StoryPublicationDate } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import Link from 'next/link';
 
+import { StoryPublicationDate } from '@/components';
 import { useDevice, useThemeSettings } from '@/hooks';
 import type { StoryWithImage } from 'types';
 

--- a/components/StoryLinks/StoryLinks.tsx
+++ b/components/StoryLinks/StoryLinks.tsx
@@ -1,6 +1,7 @@
 import { IconFacebook, IconLinkedin, IconTwitter } from '@prezly/icons';
-import { SocialShareButton } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
+
+import { SocialShareButton } from '../SocialMedia';
 
 import StoryShareUrl from './StoryShareUrl';
 

--- a/components/StoryLinks/StoryShareUrl.module.scss
+++ b/components/StoryLinks/StoryShareUrl.module.scss
@@ -4,10 +4,10 @@
 }
 
 .paste {
-    font-size: $font-size-xs;
+    font-size: $font-size-xs !important;
     height: $spacing-6;
     width: $spacing-6;
-    border: 0;
+    border: 0 !important;
 }
 
 .icon {

--- a/components/StoryLinks/StoryShareUrl.module.scss
+++ b/components/StoryLinks/StoryShareUrl.module.scss
@@ -5,11 +5,8 @@
 
 .paste {
     font-size: $font-size-xs;
-    background: $color-base-white;
     height: $spacing-6;
     width: $spacing-6;
-    align-items: center;
-    justify-content: center;
     border: 0;
 }
 

--- a/components/StoryLinks/StoryShareUrl.tsx
+++ b/components/StoryLinks/StoryShareUrl.tsx
@@ -1,10 +1,11 @@
 import { Transition } from '@headlessui/react';
 import { IconLink } from '@prezly/icons';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import { Fragment, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+
+import { Button } from '@/ui';
 
 import styles from './StoryShareUrl.module.scss';
 

--- a/components/StoryPublicationDate/StoryPublicationDate.tsx
+++ b/components/StoryPublicationDate/StoryPublicationDate.tsx
@@ -1,0 +1,18 @@
+import type { Story } from '@prezly/sdk';
+import type { AlgoliaStory } from '@prezly/theme-kit-nextjs';
+import { getStoryPublicationDate } from '@prezly/theme-kit-nextjs';
+import { FormattedDate } from 'react-intl';
+
+interface Props {
+    story: Story | AlgoliaStory;
+}
+
+export function StoryPublicationDate({ story }: Props) {
+    const date = getStoryPublicationDate(story);
+
+    if (!date) {
+        return null;
+    }
+
+    return <FormattedDate value={date} year="numeric" month="long" day="numeric" />;
+}

--- a/components/StoryPublicationDate/index.ts
+++ b/components/StoryPublicationDate/index.ts
@@ -1,0 +1,1 @@
+export { StoryPublicationDate } from './StoryPublicationDate';

--- a/components/index.ts
+++ b/components/index.ts
@@ -4,6 +4,7 @@ export { default as ContactCard } from './ContactCard';
 export { default as Dropdown } from './Dropdown';
 export { default as Error } from './Error';
 export { default as GalleryCard } from './GalleryCard';
+export { NotificationsBar } from './NotificationsBar';
 export { default as PageTitle } from './PageTitle';
 export { default as SlateRenderer } from './SlateRenderer';
 export * from './SocialMedia';

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,4 +1,5 @@
 export { default as CategoriesList } from './CategoriesList';
+export { CategoryLink } from './CategoryLink';
 export { default as ContactCard } from './ContactCard';
 export { default as Dropdown } from './Dropdown';
 export { default as Error } from './Error';

--- a/components/index.ts
+++ b/components/index.ts
@@ -9,3 +9,4 @@ export { default as SlateRenderer } from './SlateRenderer';
 export * from './StoryCards';
 export { default as StoryImage } from './StoryImage';
 export { default as StoryLinks } from './StoryLinks';
+export { StoryPublicationDate } from './StoryPublicationDate';

--- a/components/index.ts
+++ b/components/index.ts
@@ -6,6 +6,7 @@ export { default as Error } from './Error';
 export { default as GalleryCard } from './GalleryCard';
 export { default as PageTitle } from './PageTitle';
 export { default as SlateRenderer } from './SlateRenderer';
+export * from './SocialMedia';
 export * from './StoryCards';
 export { default as StoryImage } from './StoryImage';
 export { default as StoryLinks } from './StoryLinks';

--- a/modules/Errors/NotFound/NotFound.tsx
+++ b/modules/Errors/NotFound/NotFound.tsx
@@ -1,10 +1,10 @@
 import { useGetLinkLocaleSlug } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import dynamic from 'next/dynamic';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Error } from '@/components';
+import { ButtonLink } from '@/ui';
 
 import styles from './NotFound.module.scss';
 
@@ -19,9 +19,9 @@ function NotFound() {
             <Error
                 className={styles.error}
                 action={
-                    <Button.Link href="/" localeCode={getLinkLocaleSlug()} variation="primary">
+                    <ButtonLink href="/" localeCode={getLinkLocaleSlug()} variation="primary">
                         <FormattedMessage {...translations.actions.backToHomePage} />
-                    </Button.Link>
+                    </ButtonLink>
                 }
                 statusCode={404}
                 title={formatMessage(translations.notFound.title)}

--- a/modules/Galleries/Galleries.tsx
+++ b/modules/Galleries/Galleries.tsx
@@ -1,10 +1,10 @@
 import type { NewsroomGallery } from '@prezly/sdk';
 import { type PaginationProps, useInfiniteGalleriesLoading } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import { useIntl } from 'react-intl';
 
 import { PageTitle } from '@/components';
+import { Button } from '@/ui';
 
 import Layout from '../Layout';
 

--- a/modules/Gallery/DownloadLink.tsx
+++ b/modules/Gallery/DownloadLink.tsx
@@ -1,7 +1,8 @@
 import { IconDownload } from '@prezly/icons';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import { FormattedMessage } from 'react-intl';
+
+import { ButtonLink } from '@/ui';
 
 import styles from './DownloadLink.module.scss';
 
@@ -11,10 +12,10 @@ interface Props {
 
 function DownloadLink({ href }: Props) {
     return (
-        <Button.Link variation="primary" forceRefresh href={href} className={styles.link}>
+        <ButtonLink variation="primary" forceRefresh href={href} className={styles.link}>
             <FormattedMessage {...translations.actions.download} />
             <IconDownload width={16} height={16} className={styles.icon} />
-        </Button.Link>
+        </ButtonLink>
     );
 }
 

--- a/modules/InfiniteStories/InfiniteStories.tsx
+++ b/modules/InfiniteStories/InfiniteStories.tsx
@@ -1,9 +1,9 @@
 import type { Category } from '@prezly/sdk';
 import { type PaginationProps, useInfiniteStoriesLoading } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import { useIntl } from 'react-intl';
 
+import { Button } from '@/ui';
 import type { StoryWithImage } from 'types';
 
 import StoriesList from './StoriesList';

--- a/modules/Layout/Boilerplate/Boilerplate.tsx
+++ b/modules/Layout/Boilerplate/Boilerplate.tsx
@@ -7,8 +7,9 @@ import {
     useNewsroom,
 } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { SocialMedia } from '@prezly/themes-ui-components';
 import { FormattedMessage } from 'react-intl';
+
+import { SocialMedia } from '@/components';
 
 import { getWebsiteHostname } from './utils';
 

--- a/modules/Layout/CookieConsentBar/CookieConsentBar.tsx
+++ b/modules/Layout/CookieConsentBar/CookieConsentBar.tsx
@@ -1,9 +1,10 @@
 import { CookieConsentBar as DefaultCookieConsentBar } from '@prezly/analytics-nextjs';
 import { useCompanyInformation } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import { FormattedMessage } from 'react-intl';
+
+import { Button } from '@/ui';
 
 import styles from './CookieConsentBar.module.scss';
 

--- a/modules/Layout/Header/CategoriesDropdown/CategoryButton.tsx
+++ b/modules/Layout/Header/CategoriesDropdown/CategoryButton.tsx
@@ -5,7 +5,8 @@ import {
     useCurrentLocale,
     useGetLinkLocaleSlug,
 } from '@prezly/theme-kit-nextjs';
-import { Button } from '@prezly/themes-ui-components';
+
+import { ButtonLink } from '@/ui';
 
 import styles from './CategoryItem.module.scss';
 
@@ -20,7 +21,7 @@ function CategoryButton({ category, navigationButtonClassName }: Props) {
     const getLinkLocaleSlug = useGetLinkLocaleSlug();
 
     return (
-        <Button.Link
+        <ButtonLink
             variation="navigation"
             href={getCategoryUrl(category, currentLocale)}
             localeCode={getLinkLocaleSlug()}
@@ -28,7 +29,7 @@ function CategoryButton({ category, navigationButtonClassName }: Props) {
         >
             <span className={styles.title}>{name}</span>
             {description && <span className={styles.description}>{description}</span>}
-        </Button.Link>
+        </ButtonLink>
     );
 }
 

--- a/modules/Layout/Header/Header.module.scss
+++ b/modules/Layout/Header/Header.module.scss
@@ -58,7 +58,6 @@ $header-height: 88px;
 
         @include tablet-up {
             order: 10;
-            line-height: $line-height-labels;
         }
 
         &:active {

--- a/modules/Layout/Header/Header.tsx
+++ b/modules/Layout/Header/Header.tsx
@@ -7,7 +7,6 @@ import {
     useNewsroom,
 } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import Image from '@prezly/uploadcare-image';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
@@ -17,6 +16,7 @@ import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { useDevice, useDisplayedLanguages } from '@/hooks';
+import { Button, ButtonLink } from '@/ui';
 
 import CategoriesDropdown from './CategoriesDropdown';
 import LanguagesDropdown from './LanguagesDropdown';
@@ -121,7 +121,7 @@ function Header({ hasError }: Props) {
 
                     <div className={styles.navigationWrapper}>
                         {IS_SEARCH_ENABLED && (
-                            <Button.Link
+                            <ButtonLink
                                 href="/search"
                                 localeCode={getLinkLocaleSlug()}
                                 variation="navigation"
@@ -160,7 +160,7 @@ function Header({ hasError }: Props) {
                             <ul id="menu" className={styles.navigationInner}>
                                 {public_galleries_number > 0 && (
                                     <li className={styles.navigationItem}>
-                                        <Button.Link
+                                        <ButtonLink
                                             href="/media"
                                             localeCode={getLinkLocaleSlug()}
                                             variation="navigation"
@@ -169,7 +169,7 @@ function Header({ hasError }: Props) {
                                             <FormattedMessage
                                                 {...translations.mediaGallery.title}
                                             />
-                                        </Button.Link>
+                                        </ButtonLink>
                                     </li>
                                 )}
                                 <CategoriesDropdown

--- a/modules/Layout/Header/SearchWidget/SearchWidget.module.scss
+++ b/modules/Layout/Header/SearchWidget/SearchWidget.module.scss
@@ -1,19 +1,19 @@
 .modal {
-    padding: 0;
+    padding: 0 !important;
 
     @include mobile-only {
-        margin: 0;
-        height: 100%;
-        border-radius: 0;
-        box-shadow: none;
+        margin: 0 !important;
+        height: 100% !important;
+        border-radius: 0 !important;
+        box-shadow: none !important;
     }
 }
 
 .wrapper {
     @include mobile-only {
-        padding: 0;
-        min-height: 0;
-        height: 100%;
+        padding: 0 !important;
+        min-height: 0 !important;
+        height: 100% !important;
     }
 }
 

--- a/modules/Layout/Header/SearchWidget/SearchWidget.tsx
+++ b/modules/Layout/Header/SearchWidget/SearchWidget.tsx
@@ -1,9 +1,10 @@
 import { useAlgoliaSettings, useCurrentLocale } from '@prezly/theme-kit-nextjs';
-import { Modal } from '@prezly/themes-ui-components';
 import algoliasearch from 'algoliasearch/lite';
 import classNames from 'classnames';
 import { useMemo } from 'react';
 import { Configure, InstantSearch } from 'react-instantsearch-dom';
+
+import { Modal } from '@/ui';
 
 import { MainPanel, SearchBar } from './components';
 

--- a/modules/Layout/Header/SearchWidget/components/CategoriesList.tsx
+++ b/modules/Layout/Header/SearchWidget/components/CategoriesList.tsx
@@ -1,10 +1,10 @@
 import type { Category } from '@prezly/sdk';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
-import { CategoryLink } from '@/components/CategoryLink';
+import { CategoryLink } from '@/components';
+import { Button } from '@/ui';
 
 import styles from './MainPanel.module.scss';
 

--- a/modules/Layout/Header/SearchWidget/components/CategoriesList.tsx
+++ b/modules/Layout/Header/SearchWidget/components/CategoriesList.tsx
@@ -1,8 +1,10 @@
 import type { Category } from '@prezly/sdk';
 import translations from '@prezly/themes-intl-messages';
-import { Button, CategoryLink } from '@prezly/themes-ui-components';
+import { Button } from '@prezly/themes-ui-components';
 import { useMemo, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
+
+import { CategoryLink } from '@/components/CategoryLink';
 
 import styles from './MainPanel.module.scss';
 

--- a/modules/Layout/Header/SearchWidget/components/SearchBar.module.scss
+++ b/modules/Layout/Header/SearchWidget/components/SearchBar.module.scss
@@ -12,7 +12,7 @@
 }
 
 .input {
-    margin: 0;
+    margin: 0 !important;
 
     input {
         border-left: 0;

--- a/modules/Layout/Header/SearchWidget/components/SearchBar.tsx
+++ b/modules/Layout/Header/SearchWidget/components/SearchBar.tsx
@@ -1,11 +1,10 @@
 import { useGetLinkLocaleSlug } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { FormInput } from '@prezly/themes-ui-components';
 import type { SearchBoxExposed, SearchBoxProvided } from 'react-instantsearch-core';
 import { connectSearchBox } from 'react-instantsearch-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Button } from '@/ui';
+import { Button, FormInput } from '@/ui';
 
 import styles from './SearchBar.module.scss';
 

--- a/modules/Layout/Header/SearchWidget/components/SearchBar.tsx
+++ b/modules/Layout/Header/SearchWidget/components/SearchBar.tsx
@@ -1,9 +1,11 @@
 import { useGetLinkLocaleSlug } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { Button, FormInput } from '@prezly/themes-ui-components';
+import { FormInput } from '@prezly/themes-ui-components';
 import type { SearchBoxExposed, SearchBoxProvided } from 'react-instantsearch-core';
 import { connectSearchBox } from 'react-instantsearch-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
+
+import { Button } from '@/ui';
 
 import styles from './SearchBar.module.scss';
 

--- a/modules/Layout/Header/SearchWidget/components/SearchResults.tsx
+++ b/modules/Layout/Header/SearchWidget/components/SearchResults.tsx
@@ -1,11 +1,12 @@
 import type { AlgoliaStory } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import { useRouter } from 'next/router';
 import type { StateResultsProvided } from 'react-instantsearch-core';
 import { Hits } from 'react-instantsearch-dom';
 import { FormattedMessage } from 'react-intl';
+
+import { ButtonLink } from '@/ui';
 
 import Hit from './Hit';
 
@@ -31,14 +32,14 @@ function SearchResults({ searchResults, query }: Props) {
             </p>
             <Hits hitComponent={Hit} />
             {totalResults > 3 && (
-                <Button.Link
+                <ButtonLink
                     href={`/search?query=${query}`}
                     variation="navigation"
                     className={styles.link}
                     forceRefresh={isOnSearchPage}
                 >
                     <FormattedMessage {...translations.search.showAllResults} />
-                </Button.Link>
+                </ButtonLink>
             )}
         </>
     );

--- a/modules/Layout/Layout.tsx
+++ b/modules/Layout/Layout.tsx
@@ -1,10 +1,12 @@
 import { Analytics, useAnalyticsContext } from '@prezly/analytics-nextjs';
 import { PageSeo, useNewsroom, useNewsroomContext } from '@prezly/theme-kit-nextjs';
-import { LoadingBar, NotificationsBar, ScrollToTopButton } from '@prezly/themes-ui-components';
 import dynamic from 'next/dynamic';
 import { Router } from 'next/router';
 import type { PropsWithChildren } from 'react';
 import { useEffect, useState } from 'react';
+
+import { NotificationsBar } from '@/components';
+import { LoadingBar, ScrollToTopButton } from '@/ui';
 
 import Boilerplate from './Boilerplate';
 import Branding from './Branding';

--- a/modules/Layout/SubscribeForm/SubscribeForm.tsx
+++ b/modules/Layout/SubscribeForm/SubscribeForm.tsx
@@ -1,12 +1,11 @@
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { getPrivacyPortalUrl, useCurrentLocale, useNewsroom } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { FormInput } from '@prezly/themes-ui-components';
 import type { FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Button } from '@/ui';
+import { Button, FormInput } from '@/ui';
 
 import { getLocaleCodeForCaptcha, validateEmail } from './utils';
 

--- a/modules/Layout/SubscribeForm/SubscribeForm.tsx
+++ b/modules/Layout/SubscribeForm/SubscribeForm.tsx
@@ -1,10 +1,12 @@
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { getPrivacyPortalUrl, useCurrentLocale, useNewsroom } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { Button, FormInput } from '@prezly/themes-ui-components';
+import { FormInput } from '@prezly/themes-ui-components';
 import type { FormEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+
+import { Button } from '@/ui';
 
 import { getLocaleCodeForCaptcha, validateEmail } from './utils';
 

--- a/modules/Search/components/Facet.tsx
+++ b/modules/Search/components/Facet.tsx
@@ -1,11 +1,11 @@
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import { useCallback, useMemo, useState } from 'react';
 import type { RefinementListExposed, RefinementListProvided } from 'react-instantsearch-core';
 import { connectRefinementList } from 'react-instantsearch-dom';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 
-import Dropdown from '@/components/Dropdown';
+import { Dropdown } from '@/components';
+import { Button } from '@/ui';
 
 import { type ArrayElement, FacetAttribute } from '../types';
 

--- a/modules/Search/components/Hit.tsx
+++ b/modules/Search/components/Hit.tsx
@@ -1,11 +1,10 @@
 import type { AlgoliaStory } from '@prezly/theme-kit-nextjs';
-import { StoryPublicationDate } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import Link from 'next/link';
 import type { Hit } from 'react-instantsearch-core';
 import { Highlight } from 'react-instantsearch-dom';
 
-import { CategoriesList, StoryImage } from '@/components';
+import { CategoriesList, StoryImage, StoryPublicationDate } from '@/components';
 import { useThemeSettings } from '@/hooks';
 
 import styles from './Hit.module.scss';

--- a/modules/Search/components/Results.tsx
+++ b/modules/Search/components/Results.tsx
@@ -1,10 +1,11 @@
 import type { AlgoliaStory } from '@prezly/theme-kit-nextjs';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import type { Hit as HitType, InfiniteHitsProvided } from 'react-instantsearch-core';
 import { connectInfiniteHits } from 'react-instantsearch-dom';
 import { useIntl } from 'react-intl';
+
+import { Button } from '@/ui';
 
 import { useAlgoliaState } from './AlgoliaStateContext';
 import Hit from './Hit';

--- a/modules/Search/components/SearchBar.tsx
+++ b/modules/Search/components/SearchBar.tsx
@@ -1,11 +1,11 @@
 import { IconMenu } from '@prezly/icons';
 import translations from '@prezly/themes-intl-messages';
-import { Button } from '@prezly/themes-ui-components';
 import classNames from 'classnames';
 import { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import { useDevice } from '@/hooks/useDevice';
+import { Button } from '@/ui';
 
 import { AVAILABLE_FACET_ATTRIBUTES } from '../utils';
 

--- a/modules/Search/components/SearchInput.tsx
+++ b/modules/Search/components/SearchInput.tsx
@@ -1,11 +1,10 @@
 import { IconSearch } from '@prezly/icons';
 import translations from '@prezly/themes-intl-messages';
-import { FormInput } from '@prezly/themes-ui-components';
 import type { SearchBoxExposed, SearchBoxProvided } from 'react-instantsearch-core';
 import { connectSearchBox } from 'react-instantsearch-dom';
 import { useIntl } from 'react-intl';
 
-import { Button } from '@/ui';
+import { Button, FormInput } from '@/ui';
 
 import styles from './SearchInput.module.scss';
 

--- a/modules/Search/components/SearchInput.tsx
+++ b/modules/Search/components/SearchInput.tsx
@@ -1,9 +1,11 @@
 import { IconSearch } from '@prezly/icons';
 import translations from '@prezly/themes-intl-messages';
-import { Button, FormInput } from '@prezly/themes-ui-components';
+import { FormInput } from '@prezly/themes-ui-components';
 import type { SearchBoxExposed, SearchBoxProvided } from 'react-instantsearch-core';
 import { connectSearchBox } from 'react-instantsearch-dom';
 import { useIntl } from 'react-intl';
+
+import { Button } from '@/ui';
 
 import styles from './SearchInput.module.scss';
 

--- a/modules/Story/Embargo/Embargo.module.scss
+++ b/modules/Story/Embargo/Embargo.module.scss
@@ -6,6 +6,6 @@
     padding: $spacing-2;
     font-weight: $font-weight-bold;
     text-align: center;
-    background: $color-yellow-100;
-    border: 1px solid $color-yellow-500;
+    background: $color-warning-bg;
+    border: 1px solid $color-warning;
 }

--- a/modules/Story/Story.tsx
+++ b/modules/Story/Story.tsx
@@ -2,11 +2,11 @@ import { useAnalyticsContext } from '@prezly/analytics-nextjs';
 import type { ExtendedStory } from '@prezly/sdk';
 import { Story as StorySdk } from '@prezly/sdk';
 import { isEmbargoStory, StorySeo } from '@prezly/theme-kit-nextjs';
-import { StoryPublicationDate } from '@prezly/themes-ui-components';
 import Image from '@prezly/uploadcare-image';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
 
+import { StoryPublicationDate } from '@/components';
 import { useThemeSettings } from '@/hooks';
 import { getStoryImageSizes } from '@/utils';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@prezly/story-content-format": "0.59.0",
         "@prezly/theme-kit-nextjs": "3.2.4",
         "@prezly/themes-intl-messages": "1.15.3",
-        "@prezly/themes-ui-components": "0.9.0",
         "@prezly/uploadcare": "2.4.2",
         "@prezly/uploadcare-image": "0.3.2",
         "@react-hookz/web": "14.7.1",
@@ -2719,40 +2718,6 @@
       "engines": {
         "node": ">= 14.x",
         "npm": ">= 7.x"
-      }
-    },
-    "node_modules/@prezly/themes-ui-components": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@prezly/themes-ui-components/-/themes-ui-components-0.9.0.tgz",
-      "integrity": "sha512-SUn207HzDdPGrkksDE08KICj798mUKER2db69ezr8PAe3COOi6RC8tHVEhgMcttcADjUcp9YOiuJFLkiJN7yhA==",
-      "dependencies": {
-        "@headlessui/react": "^1.6.4",
-        "@prezly/icons": "^0.3.1",
-        "classnames": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 14.x",
-        "npm": ">= 7.x"
-      },
-      "peerDependencies": {
-        "@prezly/theme-kit-nextjs": "^1.x || ^2.x || ^3.x",
-        "next": "^12.x || ^13.x",
-        "react": "^17.x || ^18.x",
-        "react-dom": "^17.x || ^18.x",
-        "react-intl": "^5.x || ^6.x"
-      }
-    },
-    "node_modules/@prezly/themes-ui-components/node_modules/@prezly/icons": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@prezly/icons/-/icons-0.3.1.tgz",
-      "integrity": "sha512-Gnr2L0+9McBWjUJ05/KIcfBQEQzKQFA243cBUSJVS6+8ifmHvMgn5XDhnbmWfxWHQUjacKKxHH36wWeWIMe0nw==",
-      "engines": {
-        "node": ">= 14.x",
-        "npm": ">= 7.x"
-      },
-      "peerDependencies": {
-        "react": "^17.x || ^18.x",
-        "react-dom": "^17.x || ^18.x"
       }
     },
     "node_modules/@prezly/uploadcare": {
@@ -18344,24 +18309,6 @@
       "integrity": "sha512-AhnwRqAdABBzBD8lGY2Msls0oU0w6LHkKcb237R3Vzcf+rpzxVdQxbbarRWa/4UvTw0JJ8QOwV9L6rIWPJn6eA==",
       "requires": {
         "@formatjs/intl": "^1.16.0"
-      }
-    },
-    "@prezly/themes-ui-components": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@prezly/themes-ui-components/-/themes-ui-components-0.9.0.tgz",
-      "integrity": "sha512-SUn207HzDdPGrkksDE08KICj798mUKER2db69ezr8PAe3COOi6RC8tHVEhgMcttcADjUcp9YOiuJFLkiJN7yhA==",
-      "requires": {
-        "@headlessui/react": "^1.6.4",
-        "@prezly/icons": "^0.3.1",
-        "classnames": "^2.3.1"
-      },
-      "dependencies": {
-        "@prezly/icons": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/@prezly/icons/-/icons-0.3.1.tgz",
-          "integrity": "sha512-Gnr2L0+9McBWjUJ05/KIcfBQEQzKQFA243cBUSJVS6+8ifmHvMgn5XDhnbmWfxWHQUjacKKxHH36wWeWIMe0nw==",
-          "requires": {}
-        }
       }
     },
     "@prezly/uploadcare": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@prezly/story-content-format": "0.59.0",
     "@prezly/theme-kit-nextjs": "3.2.4",
     "@prezly/themes-intl-messages": "1.15.3",
-    "@prezly/themes-ui-components": "0.9.0",
     "@prezly/uploadcare": "2.4.2",
     "@prezly/uploadcare-image": "0.3.2",
     "@react-hookz/web": "14.7.1",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,7 +10,6 @@ import type { BasePageProps } from 'types';
 import '@prezly/content-renderer-react-js/styles.css';
 import '@prezly/uploadcare-image/build/styles.css';
 import 'modern-normalize/modern-normalize.css';
-import '@prezly/themes-ui-components/styles.css';
 import '../styles/styles.globals.scss';
 
 function App({ Component, pageProps }: AppProps) {

--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -52,6 +52,22 @@ $color-pink-500: #ec4899;
 $color-pink-600: #db2777;
 $color-pink-800: #9d174d;
 
+$color-accent-shade: #0950c3;
+$color-accent: #3b82f6;
+$color-accent-tint: #85b1f9;
+
+$color-success-shade: #136d34;
+$color-success: #22c55e;
+$color-success-tint: #51e186;
+
+$color-error-shade: #bc1010;
+$color-error: #ef4444;
+$color-error-tint: #f58a8a;
+
+$color-warning-shade: #856605;
+$color-warning: #eab308;
+$color-warning-tint: #f9cd44;
+
 $color-text: $color-base-700;
 $color-headings: $color-base-700;
 $color-borders: $color-base-200;

--- a/styles/variables/_colors.scss
+++ b/styles/variables/_colors.scss
@@ -10,52 +10,6 @@ $color-base-700: #374151;
 $color-base-800: #1f2937;
 $color-base-900: #111827;
 
-$color-red-100: #fee2e2;
-$color-red-400: #f87171;
-$color-red-500: #ef4444;
-$color-red-600: #dc2626;
-$color-red-800: #991b1b;
-
-$color-yellow-100: #fef3c7;
-$color-yellow-400: #facc15;
-$color-yellow-500: #eab308;
-$color-yellow-600: #ca8a04;
-$color-yellow-800: #92400e;
-
-$color-green-100: #d1fae5;
-$color-green-400: #4ade80;
-$color-green-500: #22c55e;
-$color-green-600: #16a34a;
-$color-green-800: #065f46;
-
-$color-blue-100: #dbeafe;
-$color-blue-400: #60a5fa;
-$color-blue-500: #3b82f6;
-$color-blue-600: #2563eb;
-$color-blue-800: #1e40af;
-
-$color-indigo-100: #e0e7ff;
-$color-indigo-400: #818cf8;
-$color-indigo-500: #6366f1;
-$color-indigo-600: #4f46e5;
-$color-indigo-800: #3730a3;
-
-$color-purple-100: #ede9fe;
-$color-purple-400: #c084fc;
-$color-purple-500: #8b5cf6;
-$color-purple-600: #9333ea;
-$color-purple-800: #5b21b6;
-
-$color-pink-100: #fce7f3;
-$color-pink-400: #f472b6;
-$color-pink-500: #ec4899;
-$color-pink-600: #db2777;
-$color-pink-800: #9d174d;
-
-$color-accent-shade: #0950c3;
-$color-accent: #3b82f6;
-$color-accent-tint: #85b1f9;
-
 $color-success-shade: #136d34;
 $color-success: #22c55e;
 $color-success-tint: #51e186;
@@ -67,7 +21,9 @@ $color-error-tint: #f58a8a;
 $color-warning-shade: #856605;
 $color-warning: #eab308;
 $color-warning-tint: #f9cd44;
+$color-warning-bg: #fef3c7;
 
+// Aliases
 $color-text: $color-base-700;
 $color-headings: $color-base-700;
 $color-borders: $color-base-200;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
       "@/modules/*": ["modules/*"],
       "@/public/*": ["public/*"],
       "@/utils": ["utils/"],
-      "@/utils/*": ["utils/*"]
+      "@/utils/*": ["utils/*"],
+      "@/ui": ["ui/"]
     }
   },
   "include": [

--- a/ui/Button/Button.module.scss
+++ b/ui/Button/Button.module.scss
@@ -1,0 +1,127 @@
+@import "variables";
+@import "mixins";
+
+.button {
+    @include border-radius-m;
+    @include text-label;
+
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    padding: $spacing-2 $spacing-3;
+    background: none;
+    font-weight: $font-weight-bold;
+    text-decoration: none;
+    appearance: none;
+    box-shadow: none;
+    cursor: pointer;
+    border: 1px solid transparent;
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.4;
+    }
+
+    &.loading {
+        cursor: wait;
+    }
+}
+
+.primary {
+    background-color: var(--prezly-accent-color);
+    border-color: var(--prezly-accent-color);
+    color: var(--prezly-accent-color-button-text);
+
+    &:not(:disabled) {
+        &:hover,
+        &:focus {
+            background-color: var(--prezly-accent-color-darkest);
+            border-color: var(--prezly-accent-color-darkest);
+        }
+
+        &:active {
+            background-color: var(--prezly-accent-color-darkest);
+            border-color: var(--prezly-accent-color-darkest);
+        }
+    }
+}
+
+.secondary {
+    border-color: $color-borders;
+    color: $color-base-700;
+
+    &:not(:disabled) {
+        &:hover {
+            border-color: $color-base-400;
+        }
+
+        &:focus,
+        &:active {
+            border-color: var(--prezly-accent-color-lightest);
+        }
+
+        &:active {
+            background-color: $color-base-50;
+        }
+    }
+}
+
+.navigation {
+    color: $color-base-700;
+    padding: $spacing-1 $spacing-2;
+
+    @include tablet-up {
+        &:not(:disabled) {
+            /* stylelint-disable-next-line max-nesting-depth */
+            &:hover,
+            &:focus {
+                opacity: 0.8;
+            }
+
+            /* stylelint-disable-next-line max-nesting-depth */
+            &:active,
+            &.active {
+                opacity: 1;
+                border-color: $color-borders;
+            }
+        }
+    }
+
+    @include mobile-only {
+        border-radius: 0;
+    }
+}
+
+.icon {
+    width: 1em;
+    height: 1em;
+
+    &.loading {
+        transform-origin: center;
+        animation: spin 1s infinite linear;
+    }
+
+    &.left {
+        margin-right: $spacing-1;
+    }
+
+    &.right {
+        margin-left: $spacing-1;
+    }
+}
+
+.iconOnly {
+    .icon {
+        margin: 0;
+    }
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/ui/Button/Button.module.scss
+++ b/ui/Button/Button.module.scss
@@ -79,8 +79,7 @@
             }
 
             /* stylelint-disable-next-line max-nesting-depth */
-            &:active,
-            &.active {
+            &:active {
                 opacity: 1;
                 border-color: $color-borders;
             }

--- a/ui/Button/Button.tsx
+++ b/ui/Button/Button.tsx
@@ -10,9 +10,6 @@ import styles from './Button.module.scss';
 export interface ButtonProps extends BaseProps, ButtonHTMLAttributes<HTMLButtonElement> {
     isLoading?: boolean;
     isDisabled?: boolean;
-    // TODO: This prop does basically nothing (and only works for navigation)
-    isActive?: boolean;
-    activeClassName?: string;
     onClick?: () => void;
     contentClassName?: string;
 }
@@ -30,8 +27,6 @@ export const Button = forwardRef<
             iconPlacement = 'left',
             isLoading,
             isDisabled,
-            isActive,
-            activeClassName,
             onClick,
             children,
             contentClassName,
@@ -48,10 +43,6 @@ export const Button = forwardRef<
                 [styles.secondary]: variation === 'secondary',
                 [styles.navigation]: variation === 'navigation',
                 [styles.loading]: isLoading,
-                [styles.active]: isActive,
-                ...(activeClassName && {
-                    [activeClassName]: isActive,
-                }),
                 [styles.iconOnly]: Boolean(icon) && !children,
             })}
             onClick={onClick}

--- a/ui/Button/Button.tsx
+++ b/ui/Button/Button.tsx
@@ -1,0 +1,74 @@
+import classNames from 'classnames';
+import type { ButtonHTMLAttributes, PropsWithChildren } from 'react';
+import { forwardRef } from 'react';
+
+import { Icon } from './Icon';
+import type { BaseProps } from './types';
+
+import styles from './Button.module.scss';
+
+export interface ButtonProps extends BaseProps, ButtonHTMLAttributes<HTMLButtonElement> {
+    isLoading?: boolean;
+    isDisabled?: boolean;
+    // TODO: This prop does basically nothing (and only works for navigation)
+    isActive?: boolean;
+    activeClassName?: string;
+    onClick?: () => void;
+    contentClassName?: string;
+}
+
+export const Button = forwardRef<
+    HTMLButtonElement,
+    Omit<PropsWithChildren<ButtonProps>, 'onResize' | 'onResizeCapture'>
+>(
+    (
+        {
+            variation,
+            className,
+            type = 'button',
+            icon,
+            iconPlacement = 'left',
+            isLoading,
+            isDisabled,
+            isActive,
+            activeClassName,
+            onClick,
+            children,
+            contentClassName,
+            ...buttonProps
+        },
+        ref,
+    ) => (
+        <button
+            ref={ref}
+            // eslint-disable-next-line react/button-has-type
+            type={type}
+            className={classNames(styles.button, className, {
+                [styles.primary]: variation === 'primary',
+                [styles.secondary]: variation === 'secondary',
+                [styles.navigation]: variation === 'navigation',
+                [styles.loading]: isLoading,
+                [styles.active]: isActive,
+                ...(activeClassName && {
+                    [activeClassName]: isActive,
+                }),
+                [styles.iconOnly]: Boolean(icon) && !children,
+            })}
+            onClick={onClick}
+            disabled={isDisabled || isLoading}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...buttonProps}
+        >
+            {iconPlacement === 'left' && (
+                <Icon icon={icon} isLoading={isLoading} placement="left" />
+            )}
+            {/* If there are no children, we insert a zero-width space to preserve the line-height */}
+            <span className={contentClassName}>{children ?? <>&#8203;</>}</span>
+            {iconPlacement === 'right' && (
+                <Icon icon={icon} isLoading={isLoading} placement="right" />
+            )}
+        </button>
+    ),
+);
+
+Button.displayName = 'Button';

--- a/ui/Button/ButtonLink.tsx
+++ b/ui/Button/ButtonLink.tsx
@@ -1,0 +1,77 @@
+import { LocaleObject, useGetLinkLocaleSlug } from '@prezly/theme-kit-nextjs';
+import classNames from 'classnames';
+import type { LinkProps as NextLinkProps } from 'next/link';
+import NextLink from 'next/link';
+import type { HTMLProps, PropsWithChildren } from 'react';
+import { forwardRef } from 'react';
+
+import { Icon } from './Icon';
+import type { BaseProps } from './types';
+
+import styles from './Button.module.scss';
+
+export interface LinkProps extends BaseProps, HTMLProps<HTMLAnchorElement> {
+    href: string;
+    localeCode?: NextLinkProps['locale'];
+    forceRefresh?: boolean;
+}
+
+export const ButtonLink = forwardRef<
+    HTMLAnchorElement,
+    Omit<PropsWithChildren<LinkProps>, 'onResize' | 'onResizeCapture'>
+>(
+    (
+        {
+            children,
+            className,
+            href,
+            icon,
+            iconPlacement = 'left',
+            variation,
+            localeCode,
+            forceRefresh,
+            ...props
+        },
+        ref,
+    ) => {
+        const getLinkLocaleSlug = useGetLinkLocaleSlug();
+        const localeUrl = localeCode
+            ? getLinkLocaleSlug(LocaleObject.fromAnyCode(localeCode))
+            : localeCode;
+
+        function renderAnchorTag(linkHref?: string) {
+            return (
+                <a
+                    href={linkHref}
+                    ref={ref}
+                    className={classNames(styles.button, className, {
+                        [styles.primary]: variation === 'primary',
+                        [styles.secondary]: variation === 'secondary',
+                        [styles.navigation]: variation === 'navigation',
+                        [styles.iconOnly]: Boolean(icon) && !children,
+                    })}
+                    // eslint-disable-next-line react/jsx-props-no-spreading
+                    {...props}
+                >
+                    {iconPlacement === 'left' && <Icon icon={icon} placement="left" />}
+                    {children && <span className={styles.label}>{children}</span>}
+                    {iconPlacement === 'right' && <Icon icon={icon} placement="right" />}
+                </a>
+            );
+        }
+
+        if (forceRefresh) {
+            const hrefWithLocale = localeUrl ? `/${localeUrl}${href.toString()}` : href.toString();
+
+            return renderAnchorTag(hrefWithLocale);
+        }
+
+        return (
+            <NextLink href={href} locale={localeUrl} passHref legacyBehavior>
+                {renderAnchorTag()}
+            </NextLink>
+        );
+    },
+);
+
+ButtonLink.displayName = 'ButtonLink';

--- a/ui/Button/Icon.tsx
+++ b/ui/Button/Icon.tsx
@@ -1,0 +1,45 @@
+import { IconLoading } from '@prezly/icons';
+import classNames from 'classnames';
+
+import type { BaseProps } from './types';
+
+import styles from './Button.module.scss';
+
+interface Props {
+    icon?: BaseProps['icon'];
+    isLoading?: boolean;
+    placement: 'left' | 'right';
+}
+
+export function Icon({ icon: IconComponent, isLoading, placement }: Props) {
+    const isLeft = placement === 'left';
+    const isRight = placement === 'right';
+
+    if (isLoading) {
+        return (
+            <IconLoading
+                width={16}
+                height={16}
+                className={classNames(styles.icon, styles.loading, {
+                    [styles.left]: isLeft,
+                    [styles.right]: isRight,
+                })}
+            />
+        );
+    }
+
+    if (IconComponent) {
+        return (
+            <IconComponent
+                width={16}
+                height={16}
+                className={classNames(styles.icon, {
+                    [styles.left]: isLeft,
+                    [styles.right]: isRight,
+                })}
+            />
+        );
+    }
+
+    return null;
+}

--- a/ui/Button/index.ts
+++ b/ui/Button/index.ts
@@ -1,0 +1,2 @@
+export { Button } from './Button';
+export { ButtonLink } from './ButtonLink';

--- a/ui/Button/types.ts
+++ b/ui/Button/types.ts
@@ -1,0 +1,8 @@
+import type { IconComponentType } from '@prezly/icons';
+
+export interface BaseProps {
+    variation: 'primary' | 'secondary' | 'navigation';
+    className?: string;
+    icon?: IconComponentType;
+    iconPlacement?: 'left' | 'right';
+}

--- a/ui/FormInput/FormInput.module.scss
+++ b/ui/FormInput/FormInput.module.scss
@@ -1,0 +1,66 @@
+@import "variables";
+@import "mixins";
+
+.wrapper {
+    display: block;
+    margin-bottom: $spacing-3;
+}
+
+.label {
+    @include sr-only;
+}
+
+.input {
+    @include text-label;
+    @include border-radius-m;
+
+    width: 100%;
+    padding: $spacing-2 $spacing-3;
+    border: 1px solid $color-base-300;
+    color: $color-base-700;
+    outline: none;
+    box-shadow: none;
+    font-weight: $font-weight-medium;
+
+    &::placeholder {
+        color: $color-base-300;
+        font-weight: $font-weight-regular;
+    }
+
+    &:hover {
+        border-color: $color-base-400;
+    }
+
+    &:focus {
+        border-color: var(--prezly-accent-color);
+    }
+}
+
+.description,
+.error {
+    @include text-tiny;
+
+    margin-top: $spacing-half;
+    margin-bottom: 0;
+    color: $color-base-500;
+}
+
+.error {
+    color: $color-error;
+}
+
+.hasError {
+    .input {
+        border-color: $color-error;
+        color: $color-error;
+
+        &::placeholder {
+            color: $color-error-tint;
+        }
+    }
+}
+
+.isDisabled {
+    opacity: 0.4;
+    pointer-events: none;
+}

--- a/ui/FormInput/FormInput.tsx
+++ b/ui/FormInput/FormInput.tsx
@@ -1,0 +1,38 @@
+import classNames from 'classnames';
+import type { InputHTMLAttributes } from 'react';
+
+import styles from './FormInput.module.scss';
+
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
+    label: string;
+    description?: string;
+    error?: string;
+    inputClassName?: string;
+}
+
+export function FormInput({
+    label,
+    description,
+    className,
+    error,
+    inputClassName,
+    ...inputProps
+}: Props) {
+    return (
+        <label
+            className={classNames(className, styles.wrapper, {
+                [styles.hasError]: Boolean(error),
+                [styles.isDisabled]: inputProps.disabled,
+            })}
+        >
+            <span className={styles.label}>{label}</span>
+            <input
+                // eslint-disable-next-line react/jsx-props-no-spreading
+                {...inputProps}
+                className={classNames(styles.input, inputClassName)}
+            />
+            {description && !error && <p className={styles.description}>{description}</p>}
+            {error && <p className={styles.error}>{error}</p>}
+        </label>
+    );
+}

--- a/ui/FormInput/index.ts
+++ b/ui/FormInput/index.ts
@@ -1,0 +1,1 @@
+export { FormInput } from './FormInput';

--- a/ui/LoadingBar/LoadingBar.module.scss
+++ b/ui/LoadingBar/LoadingBar.module.scss
@@ -1,0 +1,29 @@
+.bar {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 0.375rem;
+    background: var(--prezly-accent-color);
+    animation: grow ease-out 15s;
+    z-index: 999;
+
+    &.visible {
+        display: block;
+    }
+}
+
+@keyframes grow {
+    0% {
+        width: 0%;
+    }
+
+    20% {
+        width: 80%;
+    }
+
+    100% {
+        width: 100%;
+    }
+}

--- a/ui/LoadingBar/LoadingBar.tsx
+++ b/ui/LoadingBar/LoadingBar.tsx
@@ -1,0 +1,12 @@
+import classNames from 'classnames';
+
+import styles from './LoadingBar.module.scss';
+
+interface Props {
+    isLoading: boolean;
+    className?: string;
+}
+
+export function LoadingBar({ isLoading, className }: Props) {
+    return <div className={classNames(styles.bar, { [styles.visible]: isLoading }, className)} />;
+}

--- a/ui/LoadingBar/index.ts
+++ b/ui/LoadingBar/index.ts
@@ -1,0 +1,1 @@
+export { LoadingBar } from './LoadingBar';

--- a/ui/Modal/Modal.module.scss
+++ b/ui/Modal/Modal.module.scss
@@ -1,0 +1,76 @@
+@import "variables";
+@import "mixins";
+
+.dialog {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 10;
+    overflow-y: auto;
+}
+
+.dialogWrapper {
+    @include container;
+
+    max-width: none !important;
+    min-height: 100vh;
+    text-align: center;
+}
+
+.backdrop {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: rgba($color-base-700, 0.48);
+}
+
+.spacer {
+    display: inline-block;
+    height: 100vh;
+    vertical-align: middle;
+}
+
+.modal {
+    @include shadow-xl;
+    @include border-radius-m;
+
+    display: inline-block;
+    position: relative;
+    width: 100%;
+    max-width: 640px;
+    overflow: hidden;
+    text-align: left;
+    background: $color-base-white;
+    padding: $spacing-4;
+    margin-top: 25vh;
+}
+
+.backdropTransition {
+    transition: opacity 0.2s ease;
+}
+
+.backdropTransitionOpenStart {
+    opacity: 0;
+}
+
+.backdropTransitionOpenFinish {
+    opacity: 1;
+}
+
+.modalTransition {
+    transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.modalTransitionOpenStart {
+    opacity: 0;
+    transform: translateY(-1 * $spacing-5);
+}
+
+.modalTransitionOpenFinish {
+    opacity: 1;
+    transform: translateY(0);
+}

--- a/ui/Modal/Modal.tsx
+++ b/ui/Modal/Modal.tsx
@@ -1,0 +1,66 @@
+import { Dialog, Transition } from '@headlessui/react';
+import classNames from 'classnames';
+import type { PropsWithChildren } from 'react';
+import { Fragment } from 'react';
+
+import styles from './Modal.module.scss';
+
+interface Props {
+    id?: string;
+    isOpen: boolean;
+    onClose: () => void;
+    className?: string;
+    dialogClassName?: string;
+    wrapperClassName?: string;
+    backdropClassName?: string;
+}
+
+export function Modal({
+    id,
+    isOpen,
+    onClose,
+    className,
+    dialogClassName,
+    wrapperClassName,
+    backdropClassName,
+    children,
+}: PropsWithChildren<Props>) {
+    return (
+        <Transition appear show={isOpen} as={Fragment}>
+            <Dialog
+                as="div"
+                id={id}
+                className={classNames(styles.dialog, dialogClassName)}
+                onClose={onClose}
+            >
+                <div className={classNames(styles.dialogWrapper, wrapperClassName)}>
+                    <Transition.Child
+                        as={Fragment}
+                        enter={styles.backdropTransition}
+                        enterFrom={styles.backdropTransitionOpenStart}
+                        enterTo={styles.backdropTransitionOpenFinish}
+                        leave={styles.backdropTransition}
+                        leaveFrom={styles.backdropTransitionOpenFinish}
+                        leaveTo={styles.backdropTransitionOpenStart}
+                    >
+                        <Dialog.Overlay
+                            className={classNames(styles.backdrop, backdropClassName)}
+                        />
+                    </Transition.Child>
+
+                    <Transition.Child
+                        as={Fragment}
+                        enter={styles.modalTransition}
+                        enterFrom={styles.modalTransitionOpenStart}
+                        enterTo={styles.modalTransitionOpenFinish}
+                        leave={styles.modalTransition}
+                        leaveFrom={styles.modalTransitionOpenFinish}
+                        leaveTo={styles.modalTransitionOpenStart}
+                    >
+                        <div className={classNames(styles.modal, className)}>{children}</div>
+                    </Transition.Child>
+                </div>
+            </Dialog>
+        </Transition>
+    );
+}

--- a/ui/Modal/index.ts
+++ b/ui/Modal/index.ts
@@ -1,0 +1,1 @@
+export { Modal } from './Modal';

--- a/ui/ScrollToTopButton/ScrollToTopButton.module.scss
+++ b/ui/ScrollToTopButton/ScrollToTopButton.module.scss
@@ -1,0 +1,38 @@
+@import "variables";
+@import "mixins";
+
+// TODO: Figure out how to force a specific order of injected styles to prevent specificity issues
+.button.button {
+    position: fixed;
+    bottom: $spacing-9;
+    right: $spacing-9;
+    display: none;
+    font-size: $font-size-xs;
+    background: $color-base-white;
+    height: $spacing-6;
+    width: $spacing-6;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+
+    @include tablet-only {
+        right: $spacing-4;
+        bottom: $spacing-4;
+    }
+
+    @include mobile-only {
+        right: $spacing-3;
+        bottom: $spacing-3;
+    }
+
+    &.visible {
+        display: flex;
+    }
+}
+
+.icon {
+    width: $spacing-3;
+    height: $spacing-3;
+    transform: rotate(180deg);
+    margin-top: $spacing-1;
+}

--- a/ui/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/ui/ScrollToTopButton/ScrollToTopButton.tsx
@@ -1,0 +1,69 @@
+import { IconCaret, type IconComponentType } from '@prezly/icons';
+import classNames from 'classnames';
+import { useEffect, useState } from 'react';
+
+import { Button } from '../Button';
+
+import styles from './ScrollToTopButton.module.scss';
+
+const SCROLL_TOP_MIN_HEIGHT = 300;
+
+interface Props {
+    icon?: IconComponentType;
+    className?: string;
+    iconClassName?: string;
+    ariaLabel?: string;
+}
+
+export function ScrollToTopButton({
+    icon: IconComponent = IconCaret,
+    iconClassName,
+    className,
+    ariaLabel = 'Scroll to top',
+}: Props) {
+    const [isScrollToTopVisible, setIsScrollToTopVisible] = useState(false);
+
+    useEffect(() => {
+        function scrollListener() {
+            setIsScrollToTopVisible(
+                document.body.scrollTop > SCROLL_TOP_MIN_HEIGHT ||
+                    document.documentElement.scrollTop > SCROLL_TOP_MIN_HEIGHT,
+            );
+        }
+        if (typeof window !== 'undefined') {
+            window.onscroll = scrollListener;
+        }
+
+        return () => {
+            if (typeof window !== 'undefined') {
+                window.onscroll = null;
+            }
+        };
+    }, []);
+
+    function scrollToTop() {
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth',
+        });
+    }
+
+    return (
+        <Button
+            variation="secondary"
+            className={classNames(
+                styles.button,
+                { [styles.visible]: isScrollToTopVisible },
+                className,
+            )}
+            aria-label={ariaLabel}
+            onClick={scrollToTop}
+        >
+            <IconComponent
+                width={16}
+                height={16}
+                className={classNames(styles.icon, iconClassName)}
+            />
+        </Button>
+    );
+}

--- a/ui/ScrollToTopButton/index.ts
+++ b/ui/ScrollToTopButton/index.ts
@@ -1,0 +1,1 @@
+export { ScrollToTopButton } from './ScrollToTopButton';

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -1,0 +1,1 @@
+export { Button, ButtonLink } from './Button';

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -1,1 +1,2 @@
 export { Button, ButtonLink } from './Button';
+export { FormInput } from './FormInput';

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -1,3 +1,5 @@
 export { Button, ButtonLink } from './Button';
 export { FormInput } from './FormInput';
+export { LoadingBar } from './LoadingBar';
 export { Modal } from './Modal';
+export { ScrollToTopButton } from './ScrollToTopButton';

--- a/ui/index.ts
+++ b/ui/index.ts
@@ -1,2 +1,3 @@
 export { Button, ButtonLink } from './Button';
 export { FormInput } from './FormInput';
+export { Modal } from './Modal';


### PR DESCRIPTION
This PR ports back all of the components from the UI library we extracted some time ago.

"Dumb" UI components were ported into the new `ui` folder:
- Button (removed unused `isActive` and `activeClassName` props)
- FormInput
- LoadingBar
- Modal
- ScrollToTopButton

Other components were ported into `components`:
- CategoryLink (simplified styles to reduce the necessary overrides)
- NotificationsBar
- SocialMeda
- StoryPublicationDate

Additionally, I removed unused color swatches from SCSS colors file, and fixed issues with specificity that arose after the port.