### PR TITLE
[CARE-2257] Disable indexing for Vercel deployments

### DIFF
--- a/modules/Layout/Layout.tsx
+++ b/modules/Layout/Layout.tsx
@@ -1,4 +1,4 @@
-import { Analytics, useAnalyticsContext } from '@prezly/analytics-nextjs';
+import { Analytics } from '@prezly/analytics-nextjs';
 import { Notification, Story } from '@prezly/sdk';
 import {
     PageSeo,
@@ -34,12 +34,13 @@ const CookieConsentBar = dynamic(() => import('./CookieConsentBar'), {
     ssr: false,
 });
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 function Layout({ children, description, imageUrl, title, hasError }: PropsWithChildren<Props>) {
     const [isLoadingPage, setIsLoadingPage] = useState(false);
     const newsroom = useNewsroom();
     const story = useCurrentStory();
     const { contacts, notifications } = useNewsroomContext();
-    const { isEnabled: isAnalyticsEnabled } = useAnalyticsContext();
     const { query, pathname } = useRouter();
 
     const isSecretUrl = pathname.startsWith('/s/');
@@ -91,8 +92,8 @@ function Layout({ children, description, imageUrl, title, hasError }: PropsWithC
                 title={title}
                 description={description}
                 imageUrl={imageUrl}
-                noindex={!isAnalyticsEnabled}
-                nofollow={!isAnalyticsEnabled}
+                noindex={!isProduction}
+                nofollow={!isProduction}
             />
             <NotificationsBar notifications={displayedNotifications} />
             <CookieConsentBar />

--- a/modules/Layout/Layout.tsx
+++ b/modules/Layout/Layout.tsx
@@ -34,8 +34,6 @@ const CookieConsentBar = dynamic(() => import('./CookieConsentBar'), {
     ssr: false,
 });
 
-const isProduction = process.env.NODE_ENV === 'production';
-
 function Layout({ children, description, imageUrl, title, hasError }: PropsWithChildren<Props>) {
     const [isLoadingPage, setIsLoadingPage] = useState(false);
     const newsroom = useNewsroom();
@@ -88,13 +86,7 @@ function Layout({ children, description, imageUrl, title, hasError }: PropsWithC
         <>
             <Analytics />
             <Branding newsroom={newsroom} />
-            <PageSeo
-                title={title}
-                description={description}
-                imageUrl={imageUrl}
-                noindex={!isProduction}
-                nofollow={!isProduction}
-            />
+            <PageSeo title={title} description={description} imageUrl={imageUrl} />
             <NotificationsBar notifications={displayedNotifications} />
             <CookieConsentBar />
             <div className={styles.layout}>

--- a/modules/Layout/Layout.tsx
+++ b/modules/Layout/Layout.tsx
@@ -34,6 +34,8 @@ const CookieConsentBar = dynamic(() => import('./CookieConsentBar'), {
     ssr: false,
 });
 
+const noIndex = process.env.VERCEL === '1';
+
 function Layout({ children, description, imageUrl, title, hasError }: PropsWithChildren<Props>) {
     const [isLoadingPage, setIsLoadingPage] = useState(false);
     const newsroom = useNewsroom();
@@ -86,7 +88,13 @@ function Layout({ children, description, imageUrl, title, hasError }: PropsWithC
         <>
             <Analytics />
             <Branding newsroom={newsroom} />
-            <PageSeo title={title} description={description} imageUrl={imageUrl} />
+            <PageSeo
+                noindex={noIndex}
+                nofollow={noIndex}
+                title={title}
+                description={description}
+                imageUrl={imageUrl}
+            />
             <NotificationsBar notifications={displayedNotifications} />
             <CookieConsentBar />
             <div className={styles.layout}>

--- a/modules/Story/Story.tsx
+++ b/modules/Story/Story.tsx
@@ -1,4 +1,3 @@
-import { useAnalyticsContext } from '@prezly/analytics-nextjs';
 import type { ExtendedStory } from '@prezly/sdk';
 import { isEmbargoStory } from '@prezly/theme-kit-core';
 import { StorySeo } from '@prezly/theme-kit-nextjs';
@@ -22,9 +21,10 @@ type Props = {
     story: ExtendedStory;
 };
 
+const noIndex = process.env.VERCEL === '1';
+
 function Story({ story }: Props) {
     const { showDate } = useThemeSettings();
-    const { isEnabled: isAnalyticsEnabled } = useAnalyticsContext();
 
     if (!story) {
         return null;
@@ -36,7 +36,7 @@ function Story({ story }: Props) {
 
     return (
         <Layout>
-            <StorySeo story={story} noindex={!isAnalyticsEnabled} />
+            <StorySeo story={story} noindex={noIndex} />
             <article className={styles.story}>
                 <div className={styles.container}>
                     {isEmbargoStory(story) && <Embargo story={story} />}


### PR DESCRIPTION
Disable indexing when deployed to Vercel, will fallback to use `site.is_indexable` if not Vercel deployment, [see here](https://github.com/prezly/theme-kit-js/blob/main/packages/nextjs/src/components-nextjs/PageSeo/PageSeo.tsx#L107-L108).