### PR TITLE
[DEV-11815] Feature - Typed URL generator

### DIFF
--- a/theme-kit/router/UrlGenerator.ts
+++ b/theme-kit/router/UrlGenerator.ts
@@ -1,0 +1,24 @@
+import type { Router } from './createRouter';
+import type { Route } from './route';
+
+type WithLocaleCode<T> = T extends { localeSlug: string }
+    ? Omit<T, 'localeSlug'> & { localeCode: string }
+    : T extends { localeSlug?: string }
+    ? Omit<T, 'localeSlug'> & { localeCode?: string }
+    : T;
+
+/**
+ * Construct a type based on `Router.generate()`, but:
+ * - required `localeSlug` can be replaced with required `localeCode`
+ * - optional `localeSlug` can be replaced with optional `localeCode`
+ */
+export type UrlGenerator<T> = T extends Router<infer Routes>
+    ? <RouteName extends keyof Routes>(
+          routeName: RouteName,
+          ...params: Routes[RouteName] extends Route<infer Match>
+              ? {} extends Match
+                  ? [WithLocaleCode<Match>] | [Match] | []
+                  : [WithLocaleCode<Match>] | [Match]
+              : never
+      ) => string
+    : never;

--- a/theme-kit/router/createRouter.ts
+++ b/theme-kit/router/createRouter.ts
@@ -5,7 +5,11 @@ import { api } from '../api';
 
 import type { Route } from './route';
 
-interface Router<Routes extends Record<string, Route<unknown>>> {
+export type RoutesMap<T extends Route<unknown>> = Record<string, T>;
+
+export interface Router<Routes extends RoutesMap<Route<unknown>>> {
+    routes: Routes;
+
     match(
         path: string,
         searchParams: URLSearchParams,
@@ -31,6 +35,8 @@ export function createRouter<Routes extends Record<string, Route<unknown>>>(
     routes: Routes,
 ): Router<Routes> {
     return {
+        routes,
+
         async match(path: string, searchParams: URLSearchParams) {
             const { contentDelivery } = api();
 
@@ -57,7 +63,6 @@ export function createRouter<Routes extends Record<string, Route<unknown>>>(
             );
 
             const [first] = matches.filter(Boolean);
-
             return first;
         },
 

--- a/theme-kit/router/index.ts
+++ b/theme-kit/router/index.ts
@@ -1,2 +1,4 @@
-export { createRouter } from './createRouter';
-export { route } from './route';
+export type { UrlGenerator } from './UrlGenerator';
+
+export { createRouter, type Router } from './createRouter';
+export { route, type Route } from './route';


### PR DESCRIPTION
- Implement a wrapper around `Router.generate()` to support `localeSlug` or `localeCode` interchangeably. 