### PR TITLE
[DEV-12019] Next.js 13 - API cache layer

### DIFF
--- a/adapters/server/api.ts
+++ b/adapters/server/api.ts
@@ -20,6 +20,9 @@ export const { usePrezlyClient: api } = PrezlyAdapter.connect(
             theme: env.PREZLY_THEME_UUID,
             pinning: true,
             formats: [Story.FormatVersion.SLATEJS_V5],
+            headers: {
+                'x-newsroom-uuid': env.PREZLY_NEWSROOM_UUID,
+            },
         };
     },
     {


### PR DESCRIPTION
Attach `x-newsroom-uuid` header to all API requests

See https://github.com/prezly/ops/pull/108