### PR TITLE
Experiment: use Biome for code style

### DIFF
--- a/@types/global.d.ts
+++ b/@types/global.d.ts
@@ -1,8 +1,10 @@
 import type { PrezlyEnv } from '@prezly/theme-kit-nextjs';
 
 declare global {
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     export namespace NodeJS {
         export interface ProcessEnv extends PrezlyEnv {
+            // biome-ignore lint/style/useNamingConvention: <explanation>
             NEXT_PUBLIC_HCAPTCHA_SITEKEY: string;
         }
     }

--- a/@types/images.d.ts
+++ b/@types/images.d.ts
@@ -6,7 +6,7 @@ interface StaticImageData {
     src: string;
     height: number;
     width: number;
-    // eslint-disable-next-line @typescript-eslint/naming-convention
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     blurDataURL?: string;
 }
 

--- a/biome.json
+++ b/biome.json
@@ -19,8 +19,9 @@
       "complexity": {
         "all": false
       },
-      "performance": {
-        "all": false
+      "correctness": {
+        "noUnusedVariables": "error",
+        "useHookAtTopLevel": "error"
       },
       "a11y": {
         "useValidAnchor": "warn"

--- a/biome.json
+++ b/biome.json
@@ -28,6 +28,14 @@
       },
       "security": {
         "noDangerouslySetInnerHtml": "off"
+      },
+      "style": {
+        "useNamingConvention": {
+          "level": "warn",
+          "options": {
+            "enumMemberCase": "CONSTANT_CASE"
+          }
+        }
       }
     }
   },

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.4.1/schema.json",
+  "files": {
+    "ignore": [".next", "next-env.d.ts", "README.md", ".vscode", ".github"],
+    "ignoreUnknown": true
+  },
+  "organizeImports": {
+    "enabled": true
+  },
+  "formatter": {
+    "indentStyle": "space",
+    "indentWidth": 4,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "all": false
+      },
+      "performance": {
+        "all": false
+      },
+      "a11y": {
+        "useValidAnchor": "warn"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
+  "json": {
+    "formatter": {
+      "indentWidth": 2
+    }
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,9 @@
       },
       "a11y": {
         "useValidAnchor": "warn"
+      },
+      "security": {
+        "noDangerouslySetInnerHtml": "off"
       }
     }
   },

--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
     "rules": {
       "recommended": true,
       "complexity": {
-        "all": false
+        "noForEach": "off"
       },
       "correctness": {
         "noUnusedVariables": "error",
@@ -35,7 +35,8 @@
           "options": {
             "enumMemberCase": "CONSTANT_CASE"
           }
-        }
+        },
+        "useSingleCaseStatement": "error"
       }
     }
   },

--- a/components/CategoriesList/CategoriesList.tsx
+++ b/components/CategoriesList/CategoriesList.tsx
@@ -67,10 +67,10 @@ function CategoriesList({ categories, showAllCategories = false, isStatic, class
                 (isStatic ? (
                     <span className={styles.moreCategories}>+{hiddenCategoriesCount}</span>
                 ) : (
-                    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
                     <span
                         className={classNames(styles.moreCategories, styles.moreCategoriesLink)}
                         onClick={() => setShowExtraCategories(true)}
+                        onKeyDown={() => setShowExtraCategories(true)}
                         role="button"
                         tabIndex={0}
                     >

--- a/components/CategoryLink/CategoryLink.tsx
+++ b/components/CategoryLink/CategoryLink.tsx
@@ -24,6 +24,7 @@ export function CategoryLink({ category, className }: Props) {
             passHref
             legacyBehavior
         >
+            {/* biome-ignore lint/a11y/useValidAnchor: <explanation> */}
             <a className={classNames(styles.link, className)}>
                 <span>{name}</span>
             </a>

--- a/components/ContentRenderer/components/Attachment/Attachment.tsx
+++ b/components/ContentRenderer/components/Attachment/Attachment.tsx
@@ -25,6 +25,7 @@ export function Attachment({ node }: Props) {
     }
 
     return (
+        // biome-ignore lint/a11y/useValidAnchor: <explanation>
         <a
             id={`attachment-${file.uuid}`}
             className={styles.container}

--- a/components/ContentRenderer/components/Attachment/FileTypeIcon.tsx
+++ b/components/ContentRenderer/components/Attachment/FileTypeIcon.tsx
@@ -74,6 +74,7 @@ function getIconComponentFromExtension(extension?: string) {
 }
 
 function FileTypeIcon({ extension, className }: Props) {
+    // biome-ignore lint/style/useNamingConvention: JSX requires PascalCase
     const IconComponent = getIconComponentFromExtension(extension);
     return <IconComponent className={className} />;
 }

--- a/components/Error/Error.tsx
+++ b/components/Error/Error.tsx
@@ -11,7 +11,7 @@ interface Props {
     title: string;
 }
 
-function Error({ action, className, description, statusCode, title }: Props) {
+function ErrorLayout({ action, className, description, statusCode, title }: Props) {
     return (
         <div className={classNames(styles.error, className)}>
             <div className={styles.statusCode}>{statusCode}</div>
@@ -22,4 +22,4 @@ function Error({ action, className, description, statusCode, title }: Props) {
     );
 }
 
-export default Error;
+export default ErrorLayout;

--- a/components/RichText/Link.tsx
+++ b/components/RichText/Link.tsx
@@ -18,6 +18,7 @@ export function Link({ node, children }: Props) {
     }
 
     return (
+        // biome-ignore lint/a11y/useValidAnchor: <explanation>
         <a
             className={styles.link}
             href={href}

--- a/components/RichText/List.tsx
+++ b/components/RichText/List.tsx
@@ -10,6 +10,7 @@ interface ListProps {
 }
 
 export function List({ node, children }: PropsWithChildren<ListProps>) {
+    // biome-ignore lint/style/useNamingConvention: JSX requires PascalCase
     const Tag = node.type === ListNode.Type.NUMBERED ? 'ol' : 'ul';
 
     return (

--- a/components/StoryCards/StoryCard.tsx
+++ b/components/StoryCards/StoryCard.tsx
@@ -20,6 +20,7 @@ function StoryCard({ story, size = 'small' }: Props) {
     const { showDate, showSubtitle } = useThemeSettings();
     const { isTablet } = useDevice();
     const hasCategories = categories.length > 0;
+    // biome-ignore lint/style/useNamingConvention: JSX requires PascalCase
     const HeadingTag = size === 'small' ? 'h3' : 'h2';
     const shouldShowSubtitle = isTablet ? true : size !== 'small';
 

--- a/components/StoryImage/lib/getStoryThumbnail.ts
+++ b/components/StoryImage/lib/getStoryThumbnail.ts
@@ -6,10 +6,10 @@ import type { StoryWithImage } from 'types';
 export function getStoryThumbnail(
     story: StoryWithImage | AlgoliaStory,
 ): UploadcareImageDetails | null {
-    const { thumbnail_image } = story;
+    const { thumbnail_image: thumbnailImage } = story;
 
-    if (thumbnail_image) {
-        return JSON.parse(thumbnail_image);
+    if (thumbnailImage) {
+        return JSON.parse(thumbnailImage);
     }
 
     return null;

--- a/hooks/useThemeSettings/constants.ts
+++ b/hooks/useThemeSettings/constants.ts
@@ -4,10 +4,15 @@ import { Font } from 'types';
 export const STORAGE_KEY = 'themePreview';
 
 export const DEFAULT_THEME_SETTINGS: ThemeSettingsApiResponse = {
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     accent_color: '#3b82f6',
     font: Font.INTER,
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     header_background_color: '#ffffff',
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     header_link_color: '#4b5563',
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     show_date: true,
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     show_subtitle: false,
 };

--- a/hooks/useThemeSettings/utils.ts
+++ b/hooks/useThemeSettings/utils.ts
@@ -1,12 +1,16 @@
 import type { ThemeSettingsApiResponse } from 'types';
 
 interface ThemeSettingsQuery extends Omit<ThemeSettingsApiResponse, 'show_date' | 'show_subtitle'> {
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     show_date: string;
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     show_subtitle: string;
 }
 
 export function parseQuery(query: Partial<ThemeSettingsQuery>): Partial<ThemeSettingsApiResponse> {
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     let show_date: boolean | undefined;
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     let show_subtitle: boolean | undefined;
 
     if (Object.keys(query).length === 0) {
@@ -25,10 +29,13 @@ export function parseQuery(query: Partial<ThemeSettingsQuery>): Partial<ThemeSet
         // NOOP
     }
 
-    const settings = {
+    const settings: Partial<ThemeSettingsApiResponse> = {
+        // biome-ignore lint/style/useNamingConvention: <explanation>
         accent_color: query.accent_color,
         font: query.font,
+        // biome-ignore lint/style/useNamingConvention: <explanation>
         header_background_color: query.header_background_color,
+        // biome-ignore lint/style/useNamingConvention: <explanation>
         header_link_color: query.header_link_color,
         show_date,
         show_subtitle,

--- a/hooks/useThemeSettings/utils.ts
+++ b/hooks/useThemeSettings/utils.ts
@@ -15,13 +15,15 @@ export function parseQuery(query: Partial<ThemeSettingsQuery>): Partial<ThemeSet
 
     try {
         show_date = query.show_date ? JSON.parse(query.show_date) : undefined;
-        // eslint-disable-next-line no-empty
-    } catch (error) {}
+    } catch (_error) {
+        // NOOP
+    }
 
     try {
         show_subtitle = query.show_subtitle ? JSON.parse(query.show_subtitle) : undefined;
-        // eslint-disable-next-line no-empty
-    } catch (error) {}
+    } catch (_error) {
+        // NOOP
+    }
 
     const settings = {
         accent_color: query.accent_color,

--- a/modules/Errors/NotFound/NotFound.tsx
+++ b/modules/Errors/NotFound/NotFound.tsx
@@ -3,7 +3,7 @@ import { useGetLinkLocaleSlug } from '@prezly/theme-kit-nextjs';
 import dynamic from 'next/dynamic';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-import { Error } from '@/components';
+import { Error as ErrorComponent } from '@/components';
 import { ButtonLink } from '@/ui';
 
 import styles from './NotFound.module.scss';
@@ -16,7 +16,7 @@ function NotFound() {
 
     return (
         <Layout hasError>
-            <Error
+            <ErrorComponent
                 className={styles.error}
                 action={
                     <ButtonLink href="/" localeCode={getLinkLocaleSlug()} variation="primary">

--- a/modules/Gallery/Gallery.tsx
+++ b/modules/Gallery/Gallery.tsx
@@ -15,7 +15,7 @@ interface Props {
 }
 
 function Gallery({ gallery }: Props) {
-    const { content, name, uploadcare_group_uuid, description } = gallery;
+    const { content, name, uploadcare_group_uuid: uploadcareGroupUuid, description } = gallery;
     const galleryThumbnail = getGalleryThumbnail(gallery);
 
     const [url, setUrl] = useState('');
@@ -36,8 +36,8 @@ function Gallery({ gallery }: Props) {
                 {description && <p className={styles.description}>{description}</p>}
 
                 <div className={styles.links}>
-                    {uploadcare_group_uuid && (
-                        <DownloadLink href={getUploadcareGroupUrl(uploadcare_group_uuid, name)} />
+                    {uploadcareGroupUuid && (
+                        <DownloadLink href={getUploadcareGroupUrl(uploadcareGroupUuid, name)} />
                     )}
                     <StoryLinks url={url} className={styles.shareLinks} />
                 </div>

--- a/modules/InfiniteStories/StoriesList.tsx
+++ b/modules/InfiniteStories/StoriesList.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 function StoriesList({ stories, isCategoryList = false }: Props) {
     const { name } = useCompanyInformation();
-    const { display_name } = useNewsroom();
+    const { display_name: displayName } = useNewsroom();
 
     const [highlightedStories, restStories] = useMemo(() => {
         if (isCategoryList) {
@@ -42,7 +42,7 @@ function StoriesList({ stories, isCategoryList = false }: Props) {
                 <h1 className={styles.noStoriesTitle}>
                     <FormattedMessage
                         {...translations.noStories.title}
-                        values={{ newsroom: name || display_name }}
+                        values={{ newsroom: name || displayName }}
                     />
                 </h1>
                 <p className={styles.noStoriesSubtitle}>

--- a/modules/Layout/Boilerplate/Boilerplate.tsx
+++ b/modules/Layout/Boilerplate/Boilerplate.tsx
@@ -16,7 +16,7 @@ import styles from './Boilerplate.module.scss';
 
 function Boilerplate() {
     const companyInformation = useCompanyInformation();
-    const { display_name } = useNewsroom();
+    const { display_name: displayName } = useNewsroom();
 
     const hasAboutInformation = hasAnyAboutInformation(companyInformation);
     const hasSocialMedia = hasAnySocialMedia(companyInformation);
@@ -39,7 +39,7 @@ function Boilerplate() {
                                 <FormattedMessage
                                     {...translations.boilerplate.title}
                                     values={{
-                                        companyName: companyInformation.name || display_name,
+                                        companyName: companyInformation.name || displayName,
                                     }}
                                 />
                             </h2>

--- a/modules/Layout/Boilerplate/utils.ts
+++ b/modules/Layout/Boilerplate/utils.ts
@@ -2,7 +2,7 @@ export function getWebsiteHostname(url: string): string {
     try {
         const urlObject = new URL(url);
         return urlObject.hostname;
-    } catch (error) {
+    } catch (_error) {
         return url;
     }
 }

--- a/modules/Layout/Branding/utils.ts
+++ b/modules/Layout/Branding/utils.ts
@@ -9,12 +9,12 @@ import { FONT_FAMILY } from './constants';
 import styles from './Branding.module.scss';
 
 const accentVariationFactors = {
-    DARKEST: 18,
-    DARKER: 12,
-    DARK: 6,
-    LIGHT: 6,
-    LIGHTER: 12,
-    LIGHTEST: 18,
+    darkest: 18,
+    darker: 12,
+    dark: 6,
+    light: 6,
+    lighter: 12,
+    lightest: 18,
 };
 
 function getFontFamily(font: Font): string {
@@ -39,22 +39,22 @@ export function getCssVariables(themeSettings: ThemeSettings) {
         `--prezly-font-family: ${getFontFamily(font)}`,
         `--prezly-accent-color: ${accentColor}`,
         `--prezly-accent-color-light: ${tinycolor(accentColor)
-            .lighten(accentVariationFactors.LIGHT)
+            .lighten(accentVariationFactors.light)
             .toHexString()}`,
         `--prezly-accent-color-lighter: ${tinycolor(accentColor)
-            .lighten(accentVariationFactors.LIGHTER)
+            .lighten(accentVariationFactors.lighter)
             .toHexString()}`,
         `--prezly-accent-color-lightest: ${tinycolor(accentColor)
-            .lighten(accentVariationFactors.LIGHTEST)
+            .lighten(accentVariationFactors.lightest)
             .toHexString()}`,
         `--prezly-accent-color-dark: ${tinycolor(accentColor)
-            .darken(accentVariationFactors.DARK)
+            .darken(accentVariationFactors.dark)
             .toHexString()}`,
         `--prezly-accent-color-darker: ${tinycolor(accentColor)
-            .darken(accentVariationFactors.DARKER)
+            .darken(accentVariationFactors.darker)
             .toHexString()}`,
         `--prezly-accent-color-darkest: ${tinycolor(accentColor)
-            .darken(accentVariationFactors.DARKEST)
+            .darken(accentVariationFactors.darkest)
             .toHexString()}`,
         `--prezly-accent-color-button-text: ${accentColorButtonText}`,
         `--prezly-header-background-color: ${headerBackgroundColor}`,

--- a/modules/Layout/Header/Header.tsx
+++ b/modules/Layout/Header/Header.tsx
@@ -161,6 +161,7 @@ function Header({ hasError }: Props) {
                         <div
                             className={classNames(styles.navigation, { [styles.open]: isMenuOpen })}
                         >
+                            {/* biome-ignore lint/a11y/useKeyWithClickEvents: not adding keyboard events to not mess with the popup menu */}
                             <div role="none" className={styles.backdrop} onClick={closeMenu} />
                             <ul id="menu" className={styles.navigationInner}>
                                 {public_galleries_number > 0 && (

--- a/modules/Layout/Header/Header.tsx
+++ b/modules/Layout/Header/Header.tsx
@@ -30,23 +30,27 @@ interface Props {
 }
 
 function Header({ hasError }: Props) {
-    const { newsroom_logo, display_name, public_galleries_number } = useNewsroom();
+    const {
+        newsroom_logo: newsroomLogo,
+        display_name: displayName,
+        public_galleries_number: publicGalleriesNumber,
+    } = useNewsroom();
     const categories = useCategories();
     const displayedLanguages = useDisplayedLanguages();
     const { name } = useCompanyInformation();
     const getLinkLocaleSlug = useGetLinkLocaleSlug();
     const { formatMessage } = useIntl();
-    const { ALGOLIA_API_KEY } = useAlgoliaSettings();
+    const { ALGOLIA_API_KEY: algoliaApiKey } = useAlgoliaSettings();
     const { isMobile } = useDevice();
 
     const [isMenuOpen, setIsMenuOpen] = useState(false);
     const [isSearchWidgetShown, setIsSearchWidgetShown] = useState(false);
     const headerRef = useRef<HTMLElement>(null);
 
-    const IS_SEARCH_ENABLED = Boolean(ALGOLIA_API_KEY);
+    const isSearchEnabled = Boolean(algoliaApiKey);
 
     const shouldShowMenu =
-        categories.length > 0 || displayedLanguages.length > 0 || public_galleries_number > 0;
+        categories.length > 0 || displayedLanguages.length > 0 || publicGalleriesNumber > 0;
 
     function alignMobileHeader() {
         if (!isMobile) {
@@ -93,7 +97,7 @@ function Header({ hasError }: Props) {
         };
     }, [isMenuOpen]);
 
-    const newsroomName = name || display_name;
+    const newsroomName = name || displayName;
 
     return (
         <header ref={headerRef} className={styles.container}>
@@ -103,21 +107,21 @@ function Header({ hasError }: Props) {
                         href="/"
                         locale={getLinkLocaleSlug()}
                         className={classNames(styles.newsroom, {
-                            [styles.withoutLogo]: !newsroom_logo,
+                            [styles.withoutLogo]: !newsroomLogo,
                         })}
                     >
                         <h1
                             className={classNames(styles.title, {
-                                [styles.hidden]: newsroom_logo,
+                                [styles.hidden]: newsroomLogo,
                             })}
                         >
                             {newsroomName}
                         </h1>
-                        {newsroom_logo && (
+                        {newsroomLogo && (
                             <Image
                                 layout="fill"
                                 objectFit="contain"
-                                imageDetails={newsroom_logo}
+                                imageDetails={newsroomLogo}
                                 alt={newsroomName}
                                 className={styles.logo}
                             />
@@ -125,7 +129,7 @@ function Header({ hasError }: Props) {
                     </Link>
 
                     <div className={styles.navigationWrapper}>
-                        {IS_SEARCH_ENABLED && (
+                        {isSearchEnabled && (
                             <ButtonLink
                                 href="/search"
                                 localeCode={getLinkLocaleSlug()}
@@ -164,7 +168,7 @@ function Header({ hasError }: Props) {
                             {/* biome-ignore lint/a11y/useKeyWithClickEvents: not adding keyboard events to not mess with the popup menu */}
                             <div role="none" className={styles.backdrop} onClick={closeMenu} />
                             <ul id="menu" className={styles.navigationInner}>
-                                {public_galleries_number > 0 && (
+                                {publicGalleriesNumber > 0 && (
                                     <li className={styles.navigationItem}>
                                         <ButtonLink
                                             href="/media"
@@ -192,7 +196,7 @@ function Header({ hasError }: Props) {
                             </ul>
                         </div>
 
-                        {IS_SEARCH_ENABLED && (
+                        {isSearchEnabled && (
                             <SearchWidget
                                 dialogClassName={styles.mobileSearchWrapper}
                                 isOpen={isSearchWidgetShown}

--- a/modules/Layout/Header/SearchWidget/SearchWidget.tsx
+++ b/modules/Layout/Header/SearchWidget/SearchWidget.tsx
@@ -19,11 +19,15 @@ interface Props {
 
 function SearchWidget({ isOpen, className, dialogClassName, onClose }: Props) {
     const currentLocale = useCurrentLocale();
-    const { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX } = useAlgoliaSettings();
+    const {
+        ALGOLIA_APP_ID: algoliaAppId,
+        ALGOLIA_API_KEY: algoliaApiKey,
+        ALGOLIA_INDEX: algoliaIndex,
+    } = useAlgoliaSettings();
 
     const searchClient = useMemo(
-        () => algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY),
-        [ALGOLIA_API_KEY, ALGOLIA_APP_ID],
+        () => algoliasearch(algoliaAppId, algoliaApiKey),
+        [algoliaApiKey, algoliaAppId],
     );
 
     return (
@@ -36,7 +40,7 @@ function SearchWidget({ isOpen, className, dialogClassName, onClose }: Props) {
             wrapperClassName={styles.wrapper}
             backdropClassName={styles.backdrop}
         >
-            <InstantSearch searchClient={searchClient} indexName={ALGOLIA_INDEX}>
+            <InstantSearch searchClient={searchClient} indexName={algoliaIndex}>
                 <Configure
                     hitsPerPage={3}
                     filters={`attributes.culture.code:${currentLocale.toUnderscoreCode()}`}

--- a/modules/Layout/SubscribeForm/SubscribeForm.tsx
+++ b/modules/Layout/SubscribeForm/SubscribeForm.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/style/useNamingConvention: JSX requires PascalCase
 import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { getPrivacyPortalUrl } from '@prezly/theme-kit-core';
 import { translations } from '@prezly/theme-kit-intl';

--- a/modules/Search/SearchPage.tsx
+++ b/modules/Search/SearchPage.tsx
@@ -23,11 +23,15 @@ function SearchPage() {
     const [searchState, setSearchState] = useState<SearchState>(queryToSearchState(query));
     const debouncedSetStateRef = useRef<number>();
 
-    const { ALGOLIA_APP_ID, ALGOLIA_API_KEY, ALGOLIA_INDEX } = useAlgoliaSettings();
+    const {
+        ALGOLIA_APP_ID: algoliaAppId,
+        ALGOLIA_API_KEY: algoliaApiKey,
+        ALGOLIA_INDEX: algoliaIndex,
+    } = useAlgoliaSettings();
 
     const searchClient = useMemo(
-        () => algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_KEY),
-        [ALGOLIA_API_KEY, ALGOLIA_APP_ID],
+        () => algoliasearch(algoliaAppId, algoliaApiKey),
+        [algoliaApiKey, algoliaAppId],
     );
 
     function onSearchStateChange(updatedSearchState: SearchState) {
@@ -50,7 +54,7 @@ function SearchPage() {
         <Layout>
             <InstantSearch
                 searchClient={searchClient}
-                indexName={ALGOLIA_INDEX}
+                indexName={algoliaIndex}
                 searchState={searchState}
                 onSearchStateChange={onSearchStateChange}
                 createURL={createUrl}

--- a/modules/Search/components/Facet.tsx
+++ b/modules/Search/components/Facet.tsx
@@ -40,6 +40,7 @@ function Facet({ attribute, items, refine }: RefinementListProvided & Refinement
         }
     }, [attribute]);
 
+    // biome-ignore lint/correctness/useExhaustiveDependencies: Incorrect reporting on `typeof items`
     const getItemLabel = useCallback(
         (item: ArrayElement<typeof items>) => {
             switch (attribute) {

--- a/modules/Search/types.ts
+++ b/modules/Search/types.ts
@@ -5,7 +5,7 @@ export enum FacetAttribute {
 }
 
 export type SearchFacetsState = {
-    [k in FacetAttribute]: string[];
+    [K in FacetAttribute]: string[];
 };
 
 export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;

--- a/modules/Search/utils.ts
+++ b/modules/Search/utils.ts
@@ -13,6 +13,7 @@ const QUERY_PARAMETER_BY_ATTRIBUTE = {
 };
 
 export const AVAILABLE_FACET_ATTRIBUTES = getTypedKeys(QUERY_PARAMETER_BY_ATTRIBUTE);
+// biome-ignore lint/suspicious/noExplicitAny: Algolia search state has `any` type
 export interface SearchState extends Record<string, any> {
     query: string;
     page: number;

--- a/modules/Search/utils.ts
+++ b/modules/Search/utils.ts
@@ -47,7 +47,7 @@ export function queryToSearchState(urlQuery: ParsedUrlQuery): SearchState {
     const refinementList: Partial<SearchFacetsState> = {};
     AVAILABLE_FACET_ATTRIBUTES.forEach((key) => {
         const items = urlQuery[QUERY_PARAMETER_BY_ATTRIBUTE[key]];
-        if (items && items.length) {
+        if (items?.length) {
             refinementList[key] = Array.isArray(items) ? items : [items];
         }
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "tinycolor2": "1.6.0"
       },
       "devDependencies": {
+        "@biomejs/biome": "1.4.1",
         "@next/bundle-analyzer": "13.5.6",
         "@prezly/eslint-config": "5.2.0",
         "@svgr/webpack": "6.5.1",
@@ -1938,6 +1939,127 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.4.1.tgz",
+      "integrity": "sha512-JccVAwPbhi37pdxbAGmaOBjUTKEwEjWAhl7rKkVVuXHo4MLASXJ5HR8BTgrImi4/7rTBsGz1tgVD1Kwv1CHGRg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "1.4.1",
+        "@biomejs/cli-darwin-x64": "1.4.1",
+        "@biomejs/cli-linux-arm64": "1.4.1",
+        "@biomejs/cli-linux-x64": "1.4.1",
+        "@biomejs/cli-win32-arm64": "1.4.1",
+        "@biomejs/cli-win32-x64": "1.4.1"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.4.1.tgz",
+      "integrity": "sha512-PZWy2Idndqux38p6AXSDQM2ldRAWi32bvb7bMbTN0ALzpWYMYnxd71ornatumSSJYoNhKmxzDLq+jct7nZJ79w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.4.1.tgz",
+      "integrity": "sha512-soj3BWhnsM1M2JlzR09cibUzG1owJqetwj/Oo7yg0foijo9lNH9XWXZfJBYDKgW/6Fomn+CC2EcUS+hisQzt9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.4.1.tgz",
+      "integrity": "sha512-YIZqfJUg4F+fPsBTXxgD7EU2E5OAYbmYSl/snf4PevwfQCWE/omOFZv+NnIQmjYj9I7ParDgcJvanoA3/kO0JQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.4.1.tgz",
+      "integrity": "sha512-9YOZw3qBd/KUj63A6Hn2zZgzGb2nbESM0qNmeMXgmqinVKM//uc4OgY5TuKITuGjMSvcVxxd4dX1IzYjV9qvNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.4.1.tgz",
+      "integrity": "sha512-nWQbvkNKxYn/kCQ0yVF8kCaS3VzaGvtFSmItXiMknU4521LDjJ7tNWH12Gol+pIslrCbd4E1LhJa0a3ThRsBVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.*"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.4.1.tgz",
+      "integrity": "sha512-88fR2CQxQ4YLs2BUDuywWYQpUKgU3A3sTezANFc/4LGKQFFLV2yX+F7QAdZVkMHfA+RD9Xg178HomM/6mnTNPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.*"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
@@ -18462,6 +18584,62 @@
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@biomejs/biome": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.4.1.tgz",
+      "integrity": "sha512-JccVAwPbhi37pdxbAGmaOBjUTKEwEjWAhl7rKkVVuXHo4MLASXJ5HR8BTgrImi4/7rTBsGz1tgVD1Kwv1CHGRg==",
+      "dev": true,
+      "requires": {
+        "@biomejs/cli-darwin-arm64": "1.4.1",
+        "@biomejs/cli-darwin-x64": "1.4.1",
+        "@biomejs/cli-linux-arm64": "1.4.1",
+        "@biomejs/cli-linux-x64": "1.4.1",
+        "@biomejs/cli-win32-arm64": "1.4.1",
+        "@biomejs/cli-win32-x64": "1.4.1"
+      }
+    },
+    "@biomejs/cli-darwin-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.4.1.tgz",
+      "integrity": "sha512-PZWy2Idndqux38p6AXSDQM2ldRAWi32bvb7bMbTN0ALzpWYMYnxd71ornatumSSJYoNhKmxzDLq+jct7nZJ79w==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-darwin-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.4.1.tgz",
+      "integrity": "sha512-soj3BWhnsM1M2JlzR09cibUzG1owJqetwj/Oo7yg0foijo9lNH9XWXZfJBYDKgW/6Fomn+CC2EcUS+hisQzt9g==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.4.1.tgz",
+      "integrity": "sha512-YIZqfJUg4F+fPsBTXxgD7EU2E5OAYbmYSl/snf4PevwfQCWE/omOFZv+NnIQmjYj9I7ParDgcJvanoA3/kO0JQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-linux-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.4.1.tgz",
+      "integrity": "sha512-9YOZw3qBd/KUj63A6Hn2zZgzGb2nbESM0qNmeMXgmqinVKM//uc4OgY5TuKITuGjMSvcVxxd4dX1IzYjV9qvNQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-arm64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.4.1.tgz",
+      "integrity": "sha512-nWQbvkNKxYn/kCQ0yVF8kCaS3VzaGvtFSmItXiMknU4521LDjJ7tNWH12Gol+pIslrCbd4E1LhJa0a3ThRsBVg==",
+      "dev": true,
+      "optional": true
+    },
+    "@biomejs/cli-win32-x64": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.4.1.tgz",
+      "integrity": "sha512-88fR2CQxQ4YLs2BUDuywWYQpUKgU3A3sTezANFc/4LGKQFFLV2yX+F7QAdZVkMHfA+RD9Xg178HomM/6mnTNPA==",
+      "dev": true,
+      "optional": true
     },
     "@csstools/css-parser-algorithms": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "build": "next build",
     "build:analyze": "ANALYZE=true next build",
     "start": "next start",
+    "biome:lint": "npx @biomejs/biome lint .",
+    "biome:lint:fix": "npx @biomejs/biome lint . --apply",
+    "biome:format": "npx @biomejs/biome format .",
+    "biome:format:fix": "npx @biomejs/biome format . --write",
+    "biome:check": "npx @biomejs/biome check --apply .",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "lint-styles": "npx stylelint **.scss",
@@ -53,6 +58,7 @@
     "tinycolor2": "1.6.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.4.1",
     "@next/bundle-analyzer": "13.5.6",
     "@prezly/eslint-config": "5.2.0",
     "@svgr/webpack": "6.5.1",

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -12,6 +12,7 @@ const Story = dynamic(() => import('@/modules/Story'), { ssr: true });
 const StoryPage: NextPage<BasePageProps> = () => {
     const currentStory = useCurrentStory();
 
+    // biome-ignore lint/style/noNonNullAssertion: `currentStory` should be defined on this page
     return <Story story={currentStory!} />;
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,7 @@ import '@prezly/uploadcare-image/build/styles.css';
 import 'modern-normalize/modern-normalize.css';
 import '../styles/styles.globals.scss';
 
+// biome-ignore lint/style/useNamingConvention: JSX requires PascalCase
 function App({ Component, pageProps }: AppProps) {
     const { newsroomContextProps, translations, isTrackingEnabled, ...customPageProps } =
         pageProps as PageProps & BasePageProps;

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -73,8 +73,10 @@ ErrorPage.getInitialProps = async (context: NextPageContext): Promise<Props> => 
         extraInitialProps = { statusCode } as InternalServerErrorProps;
         // Only fetch server-side props when in SSR environment
     } else if (response) {
-        const { NextContentDelivery } = await import('@prezly/theme-kit-nextjs/server');
-        const api = NextContentDelivery.initClient(request);
+        const { NextContentDelivery: contentDelivery } = await import(
+            '@prezly/theme-kit-nextjs/server'
+        );
+        const api = contentDelivery.initClient(request);
         const { newsroomContextProps } = await api.getNewsroomServerSideProps(nextLocale);
         const translations = await importMessages(newsroomContextProps.localeCode);
 

--- a/pages/category/[slug].tsx
+++ b/pages/category/[slug].tsx
@@ -16,6 +16,7 @@ interface Props extends BasePageProps {
 const CategoryPage: FunctionComponent<Props> = ({ stories, pagination }) => {
     const currentCategory = useCurrentCategory();
 
+    // biome-ignore lint/style/noNonNullAssertion: `currentCategory` should be defined on this page
     return <Category category={currentCategory!} stories={stories} pagination={pagination} />;
 };
 

--- a/types.ts
+++ b/types.ts
@@ -18,11 +18,16 @@ export enum Font {
 }
 
 export interface ThemeSettingsApiResponse {
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     accent_color: string;
     font: Font;
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     header_background_color: string;
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     header_link_color: string;
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     show_date: boolean;
+    // biome-ignore lint/style/useNamingConvention: <explanation>
     show_subtitle: boolean;
 }
 

--- a/types.ts
+++ b/types.ts
@@ -3,6 +3,7 @@ import type { Story } from '@prezly/sdk';
 export type StoryWithImage = Story & Pick<Story.ExtraFields, 'thumbnail_image'>;
 
 export interface BasePageProps {
+    // biome-ignore lint/suspicious/noExplicitAny: The translations type is too complex to be defined here
     translations: Record<string, any>;
     isTrackingEnabled?: boolean;
 }

--- a/ui/Button/Button.tsx
+++ b/ui/Button/Button.tsx
@@ -54,7 +54,7 @@ export const Button = forwardRef<
                 <Icon icon={icon} isLoading={isLoading} placement="left" />
             )}
             {/* If there are no children, we insert a zero-width space to preserve the line-height */}
-            <span className={contentClassName}>{children ?? <>&#8203;</>}</span>
+            <span className={contentClassName}>{children ?? '&#8203;'}</span>
             {iconPlacement === 'right' && (
                 <Icon icon={icon} isLoading={isLoading} placement="right" />
             )}

--- a/ui/Button/Icon.tsx
+++ b/ui/Button/Icon.tsx
@@ -12,6 +12,7 @@ interface Props {
     placement: 'left' | 'right';
 }
 
+// biome-ignore lint/style/useNamingConvention: JSX requires PascalCase
 export function Icon({ icon: IconComponent, isLoading, placement }: Props) {
     const isLeft = placement === 'left';
     const isRight = placement === 'right';

--- a/ui/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/ui/ScrollToTopButton/ScrollToTopButton.tsx
@@ -17,6 +17,7 @@ interface Props {
 }
 
 export function ScrollToTopButton({
+    // biome-ignore lint/style/useNamingConvention: JSX requires the first letter to be capitalized
     icon: IconComponent = IconCaret,
     iconClassName,
     className,

--- a/utils/getHeaderAlignment.ts
+++ b/utils/getHeaderAlignment.ts
@@ -8,7 +8,7 @@ export function getHeaderAlignment(
     const titleNode = headingNodes.find((node) => HeadingNode.isTitleHeadingNode(node));
     const subtitleNode = headingNodes.find((node) => HeadingNode.isSubtitleHeadingNode(node));
 
-    if (subtitleNode && subtitleNode.align) {
+    if (subtitleNode?.align) {
         return subtitleNode.align;
     }
 

--- a/utils/getTypedKeys.ts
+++ b/utils/getTypedKeys.ts
@@ -1,5 +1,6 @@
 // TypeScript still has poor Object.keys definition. This is a workaround for that
 // See https://github.com/microsoft/TypeScript/issues/24243#issuecomment-405094044
+// biome-ignore lint/complexity/noBannedTypes: <explanation>
 export function getTypedKeys<T extends Object>(object: T): Array<keyof T> {
     return Object.keys(object) as Array<keyof T>;
 }

--- a/utils/makeComposableComponent.ts
+++ b/utils/makeComposableComponent.ts
@@ -5,6 +5,6 @@ export function makeComposableComponent<
     ParentComponent extends ComponentType<any>,
     // biome-ignore lint/suspicious/noExplicitAny: We're accepting any component type here
     SubComponents extends Record<string, ComponentType<any>>,
->(Component: ParentComponent, subComponents: SubComponents): ParentComponent & SubComponents {
-    return Object.assign(Component, subComponents);
+>(component: ParentComponent, subComponents: SubComponents): ParentComponent & SubComponents {
+    return Object.assign(component, subComponents);
 }

--- a/utils/makeComposableComponent.ts
+++ b/utils/makeComposableComponent.ts
@@ -1,7 +1,9 @@
 import type { ComponentType } from 'react';
 
 export function makeComposableComponent<
+    // biome-ignore lint/suspicious/noExplicitAny: We're accepting any component type here
     ParentComponent extends ComponentType<any>,
+    // biome-ignore lint/suspicious/noExplicitAny: We're accepting any component type here
     SubComponents extends Record<string, ComponentType<any>>,
 >(Component: ParentComponent, subComponents: SubComponents): ParentComponent & SubComponents {
     return Object.assign(Component, subComponents);


### PR DESCRIPTION
Our code-style setup has been overly complex for its own good, and trying to make so much tools and plugins work together is a big challenge, so I've been wondering if we could use a simpler tool.

This PR makes use of [Biome](https://biomejs.dev/) - a new all-in-one tool for linting and formatting. While it's pretty new and isn't 100% matching our current setup in terms of rules and their functionality, it does cover most of the requirements, and it is also WAAAY faster (linting only takes 20-30ms with Biome, while ESLint takes several seconds to run).

A couple drawbacks I found while experimenting:
- No option to ignore a rule for the whole file (only through the config file), requiring adding suppress comments to every line individually (a painful case with naming convention rule)
- Some rules don't have enough options to configure them to our use-case (this is by design, so far naming convention is the biggest offender)
- While the package is pretty new, false-positives happen (encountered one for exhaustive deps)
- Auto-fixing doesn't always work as intended (might be something wrong with the VS Code extension though)

Would appreciate your opinions on this one! Perhaps this would be a good time to reconsider some of the rules that we're using, maybe we don't even need that much?