### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -33,7 +33,7 @@ jobs:
           branch=${GITHUB_REF##*/}
           sha=${GITHUB_SHA::8}
           ts=$(date +%s)
-          echo "::set-output name=BUILD_ID::${branch}-${sha}-${ts}"  
+          echo "BUILD_ID=${branch}-${sha}-${ts}" >> $GITHUB_ENV  
     - uses: docker/setup-buildx-action@v1
       id: buildx
       with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -33,7 +33,7 @@ jobs:
           branch=${GITHUB_REF##*/}
           sha=${GITHUB_SHA::8}
           ts=$(date +%s)
-          echo "BUILD_ID=${branch}-${sha}-${ts}" >> $GITHUB_ENV  
+          echo "BUILD_ID=${branch}-${sha}-${ts}" >> $GITHUB_OUTPUT  
     - uses: docker/setup-buildx-action@v1
       id: buildx
       with:

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -33,7 +33,7 @@ jobs:
           branch=${GITHUB_REF##*/}
           sha=${GITHUB_SHA::8}
           ts=$(date +%s)
-          echo "BUILD_ID=${branch}-${sha}-${ts}" >> $GITHUB_OUTPUT  
+          echo "BUILD_ID=${branch}-${sha}-${ts}" >> "$GITHUB_OUTPUT"  
     - uses: docker/setup-buildx-action@v1
       id: buildx
       with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


