### PR TITLE
[DEV-12518] Feature - Make "expanded" media gallery 1120px wide

### DIFF
--- a/modules/Gallery/Gallery.module.scss
+++ b/modules/Gallery/Gallery.module.scss
@@ -3,15 +3,36 @@
 
     // TODO: This doesn't look too good.
     max-width: 720px;
-    margin: $spacing-9 auto;
+    margin: 0 auto;
 
     @include mobile-only {
         margin: $spacing-4 auto;
+    }
+
+    :global {
+        .prezly-slate-gallery.prezly-slate-gallery--expanded {
+            @media (min-width: 992px) {
+                position: relative;
+                width: 100vw;
+                left: 50%;
+                right: 50%;
+                margin-left: -50vw;
+                margin-right: -50vw;
+            }
+
+            @media (min-width: 1120px) {
+                position: static;
+                max-width: 1120px;
+                margin-left: -200px;
+            }
+        }
     }
 }
 
 .title {
     @include heading-1;
+
+    margin-top: 0;
 }
 
 .description {

--- a/modules/Gallery/Gallery.module.scss
+++ b/modules/Gallery/Gallery.module.scss
@@ -10,8 +10,9 @@
     }
 
     :global {
+        /* stylelint-disable selector-class-pattern, max-nesting-depth */
         .prezly-slate-gallery.prezly-slate-gallery--expanded {
-            @media (min-width: 992px) {
+            @media (width >= 992px) {
                 position: relative;
                 width: 100vw;
                 left: 50%;
@@ -20,12 +21,13 @@
                 margin-right: -50vw;
             }
 
-            @media (min-width: 1120px) {
+            @media (width >= 1120px) {
                 position: static;
                 max-width: 1120px;
                 margin-left: -200px;
             }
         }
+        /* stylelint-enable selector-class-pattern, max-nesting-depth */
     }
 }
 


### PR DESCRIPTION
Contained keeps the current width of 720px and expanded becomes 1120px, which is the width of the newsroom's container (minus paddings).

I've also changed the margins of the page itself, so the title is the same position as other pages (albeit offseted).

![Screenshot 2024-02-19 at 17 47 05](https://github.com/prezly/theme-nextjs-bea/assets/4209081/3d0c5f69-c195-40be-87ff-6509f0e69191)
