### PR TITLE
[DEV-12530] Fix - Use gallery's description for metadata

### DIFF
--- a/modules/Gallery/Gallery.module.scss
+++ b/modules/Gallery/Gallery.module.scss
@@ -1,8 +1,5 @@
 .container {
     width: 100%;
-
-    // TODO: This doesn't look too good.
-    max-width: 720px;
     margin: 0 auto;
 
     @include mobile-only {
@@ -11,21 +8,17 @@
 
     :global {
         /* stylelint-disable selector-class-pattern, max-nesting-depth */
-        .prezly-slate-gallery.prezly-slate-gallery--expanded {
-            @media (width >= 992px) {
-                position: relative;
-                width: 100vw;
-                left: 50%;
-                right: 50%;
-                margin-left: -50vw;
-                margin-right: -50vw;
-            }
+        .prezly-slate-gallery--contained {
+            max-width: 720px;
+        }
 
-            @media (width >= 1120px) {
-                position: static;
-                max-width: 1120px;
-                margin-left: -200px;
-            }
+        .prezly-slate-gallery--expanded {
+            position: static !important;
+            width: 100%;
+            margin-left: 0 !important;
+            margin-right: 0 !important;
+            padding-left: 0 !important;
+            padding-right: 0 !important;
         }
         /* stylelint-enable selector-class-pattern, max-nesting-depth */
     }

--- a/modules/Gallery/Gallery.module.scss
+++ b/modules/Gallery/Gallery.module.scss
@@ -25,26 +25,21 @@
 }
 
 .title {
-    @include heading-1;
-
-    margin-top: 0;
-}
-
-.description {
-    font-size: $font-size-l;
-    line-height: $line-height-l;
-    font-weight: $font-weight-regular;
-    color: $color-base-500;
+    p {
+        font-size: $font-size-l;
+        font-weight: $font-weight-regular;
+        line-height: $line-height-l;
+        color: $color-base-500;
+    }
 }
 
 .links {
     display: flex;
     align-items: center;
     flex-wrap: wrap;
+    margin-bottom: $spacing-8;
 }
 
 .shareLinks {
-    @include mobile-only {
-        margin: $spacing-2 0 0;
-    }
+    margin: 0 !important;
 }

--- a/modules/Gallery/Gallery.tsx
+++ b/modules/Gallery/Gallery.tsx
@@ -3,6 +3,7 @@ import type { Locale } from '@prezly/theme-kit-nextjs';
 import { Galleries } from '@prezly/theme-kit-nextjs';
 
 import { ContentRenderer } from '@/components/ContentRenderer';
+import { PageTitle } from '@/components/PageTitle';
 import { StoryLinks } from '@/components/StoryLinks';
 
 import { DownloadLink } from './DownloadLink';
@@ -24,8 +25,7 @@ export function Gallery({ localeCode, gallery, href }: Props) {
 
     return (
         <div className={styles.container}>
-            <h1 className={styles.title}>{name}</h1>
-            {description && <p className={styles.description}>{description}</p>}
+            <PageTitle className={styles.title} title={name} subtitle={description} />
 
             <div className={styles.links}>
                 {downloadUrl && <DownloadLink localeCode={localeCode} href={downloadUrl} />}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@prezly/content-renderer-react-js": "0.34.1",
         "@prezly/sdk": "19.10.0",
         "@prezly/story-content-format": "0.64.0",
-        "@prezly/theme-kit-nextjs": "8.2.0",
+        "@prezly/theme-kit-nextjs": "8.2.1",
         "@prezly/uploadcare": "2.4.3",
         "@prezly/uploadcare-image": "0.3.2",
         "@react-hookz/web": "14.7.1",
@@ -2745,9 +2745,9 @@
       }
     },
     "node_modules/@prezly/theme-kit-nextjs": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-8.2.0.tgz",
-      "integrity": "sha512-wk5IkOY3rZO/EHqqjdWmE3pgDJfZXzfa7Gho1xLF0lrnkcsyp++MAzfbNxnN+Yb/8jE5ATOx1eHe1J7WLfOqBg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-8.2.1.tgz",
+      "integrity": "sha512-LaKK4R1oKD0OnerCMFfUXtDql4j/+AQkICbsWGKJY+VliWuEfAaL94tE2y2niKhyG83zqkWGV286NaydkQ6STA==",
       "dependencies": {
         "@prezly/theme-kit-core": "^8.2.0",
         "@prezly/theme-kit-intl": "^8.2.0",
@@ -20006,9 +20006,9 @@
       }
     },
     "@prezly/theme-kit-nextjs": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-8.2.0.tgz",
-      "integrity": "sha512-wk5IkOY3rZO/EHqqjdWmE3pgDJfZXzfa7Gho1xLF0lrnkcsyp++MAzfbNxnN+Yb/8jE5ATOx1eHe1J7WLfOqBg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@prezly/theme-kit-nextjs/-/theme-kit-nextjs-8.2.1.tgz",
+      "integrity": "sha512-LaKK4R1oKD0OnerCMFfUXtDql4j/+AQkICbsWGKJY+VliWuEfAaL94tE2y2niKhyG83zqkWGV286NaydkQ6STA==",
       "requires": {
         "@prezly/theme-kit-core": "^8.2.0",
         "@prezly/theme-kit-intl": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@prezly/content-renderer-react-js": "0.34.1",
     "@prezly/sdk": "19.10.0",
     "@prezly/story-content-format": "0.64.0",
-    "@prezly/theme-kit-nextjs": "8.2.0",
+    "@prezly/theme-kit-nextjs": "8.2.1",
     "@prezly/uploadcare": "2.4.3",
     "@prezly/uploadcare-image": "0.3.2",
     "@react-hookz/web": "14.7.1",


### PR DESCRIPTION
- metadata was fixed in https://github.com/prezly/theme-kit-js/pull/591
- also increased the width of the gallery page, with `contained` gallery keeping the current 720px width and `expanded` will become 100% container width (1120px)
- replaced the title and description with the `PageTitle` component so it's more consistent with other pages
- also fixed spacing issues on the social links

![Screenshot 2024-02-22 at 18 21 46](https://github.com/prezly/theme-nextjs-bea/assets/4209081/b6260749-e690-44c3-9cf2-99a4753449e8)
