### PR TITLE
[DEV-12670] Increase mobile breakpoint and remove large desktop breakpoint

### DIFF
--- a/modules/Header/ui/CategoriesNav/CategoriesNavDesktop.module.scss
+++ b/modules/Header/ui/CategoriesNav/CategoriesNavDesktop.module.scss
@@ -27,7 +27,7 @@
 
 .container {
     width: 100%;
-    max-width: 1120px + 2 * 24;
+    max-width: 1200px + 2 * 24px;
     margin: 0 auto;
     padding: $spacing-4;
 }

--- a/modules/Header/ui/CategoriesNav/CategoriesNavDesktop.module.scss
+++ b/modules/Header/ui/CategoriesNav/CategoriesNavDesktop.module.scss
@@ -104,7 +104,8 @@
     text-decoration: none;
     border-radius: $border-radius-m;
 
-    &:hover {
+    &:hover,
+    &:focus {
         background: $color-base-200;
     }
 }

--- a/modules/Header/ui/Header.module.scss
+++ b/modules/Header/ui/Header.module.scss
@@ -120,6 +120,10 @@ $header-height: 88px;
     width: auto;
     max-width: 20rem;
     max-height: 3.5rem;
+
+    @include mobile-only {
+        max-width: 15rem;
+    }
 }
 
 .navigation,

--- a/modules/Search/components/SearchBar.module.scss
+++ b/modules/Search/components/SearchBar.module.scss
@@ -53,7 +53,7 @@
         min-width: 300px;
     }
 
-    @include desktop-large-up {
+    @include desktop-up {
         min-width: 450px;
     }
 }

--- a/styles/mixins/_container.scss
+++ b/styles/mixins/_container.scss
@@ -15,11 +15,6 @@
         padding-right: $grid-spacing-desktop;
         max-width: $grid-container-max-width;
     }
-
-    @include desktop-large-up {
-        padding-left: $grid-spacing-desktop-large;
-        padding-right: $grid-spacing-desktop-large;
-    }
 }
 
 /*

--- a/styles/mixins/_responsive.scss
+++ b/styles/mixins/_responsive.scss
@@ -1,31 +1,25 @@
 @import "../variables/breakpoints";
 
 @mixin mobile-only {
-    @media screen and (max-width: $breakpoint-tablet) {
+    @media screen and (max-width: $breakpoint-tablet - 1px) {
         @content;
     }
 }
 
 @mixin tablet-up {
-    @media screen and (min-width: $breakpoint-tablet + 1px) {
+    @media screen and (min-width: $breakpoint-tablet) {
         @content;
     }
 }
 
 @mixin tablet-only {
-    @media screen and (min-width: $breakpoint-tablet + 1px) and (max-width: $breakpoint-desktop) {
+    @media screen and (min-width: $breakpoint-tablet) and (max-width: $breakpoint-desktop) {
         @content;
     }
 }
 
 @mixin desktop-up {
-    @media screen and (min-width: $breakpoint-desktop + 1px) {
-        @content;
-    }
-}
-
-@mixin desktop-large-up {
-    @media screen and (min-width: $breakpoint-desktop-large + 1px) {
+    @media screen and (min-width: $breakpoint-desktop) {
         @content;
     }
 }

--- a/styles/variables/_breakpoints.scss
+++ b/styles/variables/_breakpoints.scss
@@ -1,3 +1,2 @@
-$breakpoint-tablet: 414px;
-$breakpoint-desktop: 768px;
-$breakpoint-desktop-large: 1024px;
+$breakpoint-tablet: 768px;
+$breakpoint-desktop: 1024px;

--- a/styles/variables/_spacing.scss
+++ b/styles/variables/_spacing.scss
@@ -18,6 +18,5 @@ $grid-gutter-tablet: 2rem; // 32px
 $grid-spacing-tablet: 2rem; // 32px
 $grid-gutter-desktop: 2.5rem; // 40px
 $grid-spacing-desktop: 2.5rem; // 40px
-$grid-spacing-desktop-large: 5rem; // 80px
 
 $grid-container-max-width: 1280px; // 1120px + 80px spacing on the sides


### PR DESCRIPTION
Preview: https://theme-nextjs-bea-preview-crlieg74x-prezly1.vercel.app/

- removed mobile breakpoint so now the mobile header appears below tablet breakpoint (767px)
- reduced max-width of logo on mobile
- increased max-width of categories dropdown content on desktop
- regular categories in categories dropdown will now have the hover state when focused as well