### PR TITLE
[DEV-12675] FIx - Improved mobile menu styling, desktop categories menu layouts and hardcoded colors

### DIFF
--- a/components/Dropdown/DropdownItem.module.scss
+++ b/components/Dropdown/DropdownItem.module.scss
@@ -30,12 +30,4 @@
             border: 0;
         }
     }
-
-    &:first-child > .link {
-        padding-top: $spacing-3;
-    }
-
-    &:last-child > .link {
-        padding-bottom: $spacing-3;
-    }
 }

--- a/modules/Header/ui/CategoriesNav/CategoriesNavDesktop.module.scss
+++ b/modules/Header/ui/CategoriesNav/CategoriesNavDesktop.module.scss
@@ -47,6 +47,7 @@
         display: grid;
         grid-template-columns: repeat(3, 1fr);
         gap: 0 $spacing-2;
+        align-items: flex-start;
     }
 
     .separator {

--- a/modules/Header/ui/CategoriesNav/CategoriesNavDesktop.module.scss
+++ b/modules/Header/ui/CategoriesNav/CategoriesNavDesktop.module.scss
@@ -99,7 +99,7 @@
     @include text-label;
 
     padding: $spacing-1 $spacing-2;
-    color: var(--prezly-header-link-color);
+    color: $color-text;
     font-weight: $font-weight-medium;
     text-decoration: none;
     border-radius: $border-radius-m;

--- a/modules/Header/ui/CategoriesNav/CategoriesNavMobile.module.scss
+++ b/modules/Header/ui/CategoriesNav/CategoriesNavMobile.module.scss
@@ -17,7 +17,7 @@
 }
 
 .dropdown {
-    padding-bottom: $spacing-3 !important;
+    padding: $spacing-3 0 !important;
     background: $color-base-50;
 }
 
@@ -25,7 +25,7 @@
     display: grid;
     grid-template-columns: repeat(2, 1fr);
     gap: $spacing-4;
-    padding: $spacing-3 $spacing-4 0;
+    padding: 0 $spacing-4;
 }
 
 .regularContainer {

--- a/modules/Header/ui/CategoriesNav/CategoriesNavMobile.module.scss
+++ b/modules/Header/ui/CategoriesNav/CategoriesNavMobile.module.scss
@@ -1,5 +1,4 @@
 .container {
-    margin: 0 $grid-spacing-mobile;
     display: none;
 
     @include mobile-only {
@@ -14,16 +13,21 @@
 .divider {
     border: none;
     border-top: 1px solid $color-borders;
-    margin: $spacing-2 0;
+    margin: $spacing-4;
+}
+
+.dropdown {
+    padding-bottom: $spacing-3 !important;
+    background: $color-base-50;
 }
 
 .featuredContainer {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
     gap: $spacing-4;
-    flex-flow: row wrap;
-    padding-bottom: $spacing-2;
+    padding: $spacing-3 $spacing-4 0;
 }
 
-.featuredItem {
-    flex: 1 0 calc(50% - $spacing-2);
+.regularContainer {
+    padding: 0 $spacing-half;
 }

--- a/modules/Header/ui/CategoriesNav/CategoriesNavMobile.tsx
+++ b/modules/Header/ui/CategoriesNav/CategoriesNavMobile.tsx
@@ -4,7 +4,6 @@ import { translations } from '@prezly/theme-kit-nextjs/index';
 
 import { FormattedMessage } from '@/adapters/client';
 import { Dropdown } from '@/components/Dropdown';
-import { Link } from '@/components/Link';
 
 import { CategoryItem } from './CategoryItem';
 import { FeaturedCategory } from './FeaturedCategory';

--- a/modules/Header/ui/CategoriesNav/CategoriesNavMobile.tsx
+++ b/modules/Header/ui/CategoriesNav/CategoriesNavMobile.tsx
@@ -4,6 +4,7 @@ import { translations } from '@prezly/theme-kit-nextjs/index';
 
 import { FormattedMessage } from '@/adapters/client';
 import { Dropdown } from '@/components/Dropdown';
+import { Link } from '@/components/Link';
 
 import { CategoryItem } from './CategoryItem';
 import { FeaturedCategory } from './FeaturedCategory';
@@ -37,33 +38,33 @@ export function CategoriesNavMobile({
                     label={
                         <FormattedMessage locale={localeCode} for={translations.categories.title} />
                     }
+                    menuClassName={styles.dropdown}
                     buttonClassName={navigationItemButtonClassName}
                     withMobileDisplay
                     forceOpen={showAllCategories}
                 >
                     {featuredCategories.length > 0 && (
-                        <li className={styles.container}>
-                            <div className={styles.featuredContainer}>
-                                {featuredCategories.map((category) => (
-                                    <FeaturedCategory
-                                        key={category.id}
-                                        className={styles.featuredItem}
-                                        category={getCategory(category)}
-                                        translatedCategory={category}
-                                        size="small"
-                                    />
-                                ))}
-                            </div>
-                        </li>
+                        <div className={styles.featuredContainer}>
+                            {featuredCategories.map((category) => (
+                                <FeaturedCategory
+                                    key={category.id}
+                                    category={getCategory(category)}
+                                    translatedCategory={category}
+                                    size="small"
+                                />
+                            ))}
+                        </div>
                     )}
                     {featuredCategories.length > 0 && regularCategories.length > 0 && (
-                        <li className={styles.container}>
-                            <hr className={styles.divider} />
-                        </li>
+                        <hr className={styles.divider} />
                     )}
-                    {regularCategories.map((category) => (
-                        <CategoryItem key={category.id} category={category} />
-                    ))}
+                    {regularCategories.length > 0 && (
+                        <div className={styles.regularContainer}>
+                            {regularCategories.map((category) => (
+                                <CategoryItem key={category.id} category={category} />
+                            ))}
+                        </div>
+                    )}
                 </Dropdown>
             </li>
         </>

--- a/modules/Header/ui/CategoriesNav/CategoryItem.module.scss
+++ b/modules/Header/ui/CategoriesNav/CategoryItem.module.scss
@@ -1,21 +1,7 @@
 .title {
     display: block;
     text-transform: capitalize;
-    color: var(--prezly-header-link-color);
+    color: $color-text;
     font-weight: $font-weight-medium;
     text-decoration: none;
-}
-
-.description {
-    @include text-small;
-    @include line-clamp(2);
-
-    display: block;
-    margin-top: $spacing-1;
-    color: $color-base-500;
-    font-weight: $font-weight-regular;
-
-    @include mobile-only {
-        display: none;
-    }
 }

--- a/modules/Header/ui/CategoriesNav/CategoryItem.tsx
+++ b/modules/Header/ui/CategoriesNav/CategoryItem.tsx
@@ -7,6 +7,7 @@ import styles from './CategoryItem.module.scss';
 export function CategoryItem({ category }: CategoryItem.Props) {
     return (
         <DropdownItem
+            className={styles.item}
             href={{
                 routeName: 'category',
                 params: { slug: category.slug, localeCode: category.locale },
@@ -14,9 +15,6 @@ export function CategoryItem({ category }: CategoryItem.Props) {
             withMobileDisplay
         >
             <span className={styles.title}>{category.name}</span>
-            {category.description && (
-                <span className={styles.description}>{category.description}</span>
-            )}
         </DropdownItem>
     );
 }

--- a/modules/Header/ui/CategoriesNav/FeaturedCategory.module.scss
+++ b/modules/Header/ui/CategoriesNav/FeaturedCategory.module.scss
@@ -4,7 +4,7 @@
     display: flex;
     flex-direction: column;
     text-decoration: none;
-    color: var(--prezly-header-link-color);
+    color: $color-text;
     font-weight: $font-weight-medium;
 }
 

--- a/modules/Header/ui/CategoriesNav/FeaturedCategory.module.scss
+++ b/modules/Header/ui/CategoriesNav/FeaturedCategory.module.scss
@@ -10,6 +10,8 @@
 
 .image {
     margin-bottom: $spacing-1;
+    height: auto;
+    aspect-ratio: 1.25;
 
     img {
         border-radius: $border-radius-s;

--- a/modules/Header/ui/CategoriesNav/FeaturedCategory.tsx
+++ b/modules/Header/ui/CategoriesNav/FeaturedCategory.tsx
@@ -31,9 +31,7 @@ export function FeaturedCategory({
                 translatedCategory={translatedCategory}
                 size={size}
             />
-            <div className={styles.name}>
-                {translatedCategory.name} {translatedCategory.name}
-            </div>
+            {translatedCategory.name}
         </Link>
     );
 }

--- a/modules/Header/ui/Header.module.scss
+++ b/modules/Header/ui/Header.module.scss
@@ -30,20 +30,19 @@ $header-height: 88px;
         color: var(--prezly-header-link-color);
 
         @include mobile-only {
+            @include text-label;
+
             display: flex;
             text-align: left;
             justify-content: flex-start;
             padding: $spacing-4 $grid-gutter-mobile;
-            color: inherit;
-            font-size: $font-size-m;
-            font-weight: $font-weight-bold;
+            color: $color-text;
         }
 
         &:hover,
         &:active,
         &:focus {
             opacity: 1 !important;
-            color: var(--prezly-header-link-hover-color) !important;
         }
 
         &:active {

--- a/modules/Header/ui/LanguagesDropdown/LanguagesDropdown.module.scss
+++ b/modules/Header/ui/LanguagesDropdown/LanguagesDropdown.module.scss
@@ -1,10 +1,9 @@
-.container {
+.menu {
     @include mobile-only {
+        padding: $spacing-1 0 !important;
         background: $color-base-50;
     }
-}
 
-.menu {
     @include tablet-up {
         max-height: 50vh;
         overflow: auto;

--- a/modules/Header/ui/LanguagesDropdown/LanguagesDropdown.tsx
+++ b/modules/Header/ui/LanguagesDropdown/LanguagesDropdown.tsx
@@ -23,7 +23,6 @@ export function LanguagesDropdown({
             <Dropdown
                 icon={IconGlobe}
                 label={selectedOption?.title}
-                className={styles.container}
                 menuClassName={styles.menu}
                 buttonClassName={classNames(buttonClassName, styles.button)}
                 withMobileDisplay


### PR DESCRIPTION
Preview: https://theme-nextjs-bea-preview-gafk9kw9t-prezly1.vercel.app/

- mobile menu and categories dropdown hardcoded to use the text color
- added faint gray background to opened dropdowns in mobile menu
- fixed layout of featured categories in categories dropdown on desktop