### PR TITLE
[DEV-12776] Fix - Story UUID is not passed into analytics context provider

### DIFF
--- a/app/[localeCode]/(story)/components.tsx
+++ b/app/[localeCode]/(story)/components.tsx
@@ -1,7 +1,7 @@
 import type { ExtendedStory } from '@prezly/sdk';
 import { Notification } from '@prezly/sdk';
 
-import { BroadcastNotifications, BroadcastTranslations } from '@/modules/Broadcast';
+import { BroadcastNotifications, BroadcastStory, BroadcastTranslations } from '@/modules/Broadcast';
 
 interface Props {
     story: ExtendedStory;
@@ -25,6 +25,7 @@ export function Broadcast({ story, isPreview }: Props) {
 
     return (
         <>
+            <BroadcastStory story={story} />
             {isPreview && <BroadcastNotifications notifications={[PREVIEW_WARNING]} />}
             <BroadcastTranslations translations={translations} />
         </>

--- a/app/[localeCode]/layout.tsx
+++ b/app/[localeCode]/layout.tsx
@@ -4,7 +4,7 @@ import type { Viewport } from 'next';
 import type { ReactNode } from 'react';
 
 import { ThemeSettingsProvider } from '@/adapters/client';
-import { app, generateRootMetadata, themeSettings } from '@/adapters/server';
+import { analytics, app, generateRootMetadata, themeSettings } from '@/adapters/server';
 import { CategoryImageFallbackProvider } from '@/components/CategoryImage';
 import { ScrollToTopButton } from '@/components/ScrollToTopButton';
 import { StoryImageFallbackProvider } from '@/components/StoryImage';
@@ -13,6 +13,7 @@ import { Boilerplate } from '@/modules/Boilerplate';
 import {
     BroadcastNotificationsProvider,
     BroadcastPageTypesProvider,
+    BroadcastStoryProvider,
     BroadcastTranslationsProvider,
 } from '@/modules/Broadcast';
 import { CookieConsent } from '@/modules/CookieConsent';
@@ -100,28 +101,31 @@ async function AppContext(props: { children: ReactNode; localeCode: Locale.Code 
     const languageSettings = await app().languageOrDefault(localeCode);
     const brandName = languageSettings.company_information.name || newsroom.name;
     const settings = await app().themeSettings();
+    const { isTrackingEnabled } = analytics();
 
     return (
         <RoutingProvider>
             <IntlProvider localeCode={localeCode}>
-                <AnalyticsProvider>
-                    <StoryImageFallbackProvider image={newsroom.newsroom_logo} text={brandName}>
-                        <CategoryImageFallbackProvider
-                            image={newsroom.newsroom_logo}
-                            text={brandName}
-                        >
-                            <ThemeSettingsProvider settings={settings}>
-                                <BroadcastPageTypesProvider>
-                                    <BroadcastNotificationsProvider>
-                                        <BroadcastTranslationsProvider>
-                                            {children}
-                                        </BroadcastTranslationsProvider>
-                                    </BroadcastNotificationsProvider>
-                                </BroadcastPageTypesProvider>
-                            </ThemeSettingsProvider>
-                        </CategoryImageFallbackProvider>
-                    </StoryImageFallbackProvider>
-                </AnalyticsProvider>
+                <BroadcastStoryProvider>
+                    <AnalyticsProvider isEnabled={isTrackingEnabled} newsroom={newsroom}>
+                        <StoryImageFallbackProvider image={newsroom.newsroom_logo} text={brandName}>
+                            <CategoryImageFallbackProvider
+                                image={newsroom.newsroom_logo}
+                                text={brandName}
+                            >
+                                <ThemeSettingsProvider settings={settings}>
+                                    <BroadcastPageTypesProvider>
+                                        <BroadcastNotificationsProvider>
+                                            <BroadcastTranslationsProvider>
+                                                {children}
+                                            </BroadcastTranslationsProvider>
+                                        </BroadcastNotificationsProvider>
+                                    </BroadcastPageTypesProvider>
+                                </ThemeSettingsProvider>
+                            </CategoryImageFallbackProvider>
+                        </StoryImageFallbackProvider>
+                    </AnalyticsProvider>
+                </BroadcastStoryProvider>
             </IntlProvider>
         </RoutingProvider>
     );

--- a/modules/Broadcast/BroadcastStory.tsx
+++ b/modules/Broadcast/BroadcastStory.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type { Story } from '@prezly/sdk';
+import type { ReactNode } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+type Revoke = () => void;
+
+interface Context {
+    story: Story | null;
+    broadcast: (story: Story) => Revoke;
+}
+
+const context = createContext<Context>({
+    story: null,
+    broadcast() {
+        throw new Error(
+            'This functionality requires `BroadcastStoryProvider` mounted up the components tree.',
+        );
+    },
+});
+
+export function BroadcastStoryProvider(props: { children: ReactNode }) {
+    const [story, setStory] = useState<Story | null>(null);
+
+    const broadcast = useCallback((storyToBroadcast: Story) => {
+        setStory(storyToBroadcast);
+
+        return () => setStory(null);
+    }, []);
+
+    const value = useMemo(() => ({ story, broadcast }), [broadcast, story]);
+
+    return <context.Provider value={value}>{props.children}</context.Provider>;
+}
+export function BroadcastStory(props: { story: Story }) {
+    useBroadcastStory(props.story);
+
+    return null;
+}
+
+export function useBroadcastStory(story: Story) {
+    const { broadcast } = useContext(context);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => broadcast(story), [story]);
+}
+
+export function useBroadcastedStory(): Story | null {
+    return useContext(context).story;
+}

--- a/modules/Broadcast/index.ts
+++ b/modules/Broadcast/index.ts
@@ -1,3 +1,4 @@
 export * from './BroadcastNotifications';
 export * from './BroadcastPageType';
+export * from './BroadcastStory';
 export * from './BroadcastTranslations';


### PR DESCRIPTION
This is a bit of a hacky solution but I've spent quite some time on this already and couldn't find a better solution without majorly rethinking the whole analytics package.

By using the debounced function (which uses timeout), the `page` call is only triggered after the contexts are updated and components are re-rendered, making it so that all the data is up to date.

In order for this solution to work, it requires disabling automatic page tracking that I've prepared in https://github.com/prezly/analytics/pull/299.