### PR TITLE
[DEV-12794] Fix - Do not track links with Uploadcare CDN as outbound

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hcaptcha/react-hcaptcha": "1.9.3",
         "@headlessui/react": "1.7.18",
         "@playwright/test": "^1.33.0",
-        "@prezly/analytics-nextjs": "2.1.1",
+        "@prezly/analytics-nextjs": "2.1.2",
         "@prezly/content-renderer-react-js": "0.36.1",
         "@prezly/sdk": "20.3.0",
         "@prezly/story-content-format": "0.64.0",
@@ -2973,9 +2973,9 @@
       "dev": true
     },
     "node_modules/@prezly/analytics-nextjs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@prezly/analytics-nextjs/-/analytics-nextjs-2.1.1.tgz",
-      "integrity": "sha512-IbPG2I4FxvyfEVSiOmdhw20eviZrWjlXKIdFx5t0autg+yehoVzsRFKwHxucBzrTEEGqgiA0E/39N48NkU/aPQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@prezly/analytics-nextjs/-/analytics-nextjs-2.1.2.tgz",
+      "integrity": "sha512-K2HzlH/wS8lD+nB2wElfgpCZHcg4swTOWMel+590nrGOT8s4/nWpbKlIT4mpDzbl3gHM4G62YIcxrAR6/vg1oQ==",
       "dependencies": {
         "@react-hookz/web": "^14.2.2",
         "@segment/analytics-next": "^1.66.0",
@@ -20646,9 +20646,9 @@
       "dev": true
     },
     "@prezly/analytics-nextjs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@prezly/analytics-nextjs/-/analytics-nextjs-2.1.1.tgz",
-      "integrity": "sha512-IbPG2I4FxvyfEVSiOmdhw20eviZrWjlXKIdFx5t0autg+yehoVzsRFKwHxucBzrTEEGqgiA0E/39N48NkU/aPQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@prezly/analytics-nextjs/-/analytics-nextjs-2.1.2.tgz",
+      "integrity": "sha512-K2HzlH/wS8lD+nB2wElfgpCZHcg4swTOWMel+590nrGOT8s4/nWpbKlIT4mpDzbl3gHM4G62YIcxrAR6/vg1oQ==",
       "requires": {
         "@react-hookz/web": "^14.2.2",
         "@segment/analytics-next": "^1.66.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@hcaptcha/react-hcaptcha": "1.9.3",
     "@headlessui/react": "1.7.18",
     "@playwright/test": "^1.33.0",
-    "@prezly/analytics-nextjs": "2.1.1",
+    "@prezly/analytics-nextjs": "2.1.2",
     "@prezly/content-renderer-react-js": "0.36.1",
     "@prezly/sdk": "20.3.0",
     "@prezly/story-content-format": "0.64.0",


### PR DESCRIPTION
Actual fix is in https://github.com/prezly/analytics/pull/302.