### PR TITLE
[CARE-5022] Feature - Create a mask when preview=true query parameter is present

### DIFF
--- a/app/[localeCode]/layout.tsx
+++ b/app/[localeCode]/layout.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 import { ThemeSettingsProvider } from '@/adapters/client';
 import { analytics, app, generateRootMetadata, themeSettings } from '@/adapters/server';
 import { CategoryImageFallbackProvider } from '@/components/CategoryImage';
+import { PreviewPageMask } from '@/components/PreviewPageMask';
 import { ScrollToTopButton } from '@/components/ScrollToTopButton';
 import { StoryImageFallbackProvider } from '@/components/StoryImage';
 import { AnalyticsProvider } from '@/modules/Analytics';
@@ -87,6 +88,7 @@ export default async function MainLayout({ children, params }: Props) {
                     </div>
                     <ScrollToTopButton />
                     <CookieConsent localeCode={localeCode} />
+                    <PreviewPageMask />
                 </AppContext>
             </body>
         </html>

--- a/components/PreviewPageMask/PreviewPageMask.module.scss
+++ b/components/PreviewPageMask/PreviewPageMask.module.scss
@@ -1,0 +1,6 @@
+.mask {
+    position: fixed;
+    inset: 0;
+    background: transparent;
+    z-index: 9999;
+}

--- a/components/PreviewPageMask/PreviewPageMask.tsx
+++ b/components/PreviewPageMask/PreviewPageMask.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+import styles from './PreviewPageMask.module.scss';
+
+export function PreviewPageMask() {
+    const searchParams = useSearchParams();
+    const preview = JSON.parse(searchParams.get('preview') ?? 'false');
+
+    if (!preview) {
+        return null;
+    }
+
+    return <div className={styles.mask} />;
+}

--- a/components/PreviewPageMask/index.ts
+++ b/components/PreviewPageMask/index.ts
@@ -1,0 +1,1 @@
+export { PreviewPageMask } from './PreviewPageMask';


### PR DESCRIPTION
Implemented a component that creates a fixed overlay covering the entire page, preventing the user from clicking anything, but still allow scrolling.

This functionality only works when `preview=true` query parameter is present and is intended to work with our live theme preview functionality.