### PR TITLE
[CARE-5028] Fix - Parse preview search params in DynamicPreviewBranding

### DIFF
--- a/hooks/useThemeSettingsWithPreview/useThemeSettingsWithPreview.ts
+++ b/hooks/useThemeSettingsWithPreview/useThemeSettingsWithPreview.ts
@@ -5,13 +5,12 @@ import { useMemo } from 'react';
 
 import { useThemeSettings } from 'adapters/client/theme-settings';
 import type { ThemeSettings } from 'theme-settings';
-
-import { parseSearchParams } from './parseSearchParams';
+import { parsePreviewSearchParams } from 'utils';
 
 export function useThemeSettingsWithPreview(): ThemeSettings {
     const searchParams = useSearchParams();
     const themeSettings = useThemeSettings();
-    const previewSettings = parseSearchParams(searchParams);
+    const previewSettings = parsePreviewSearchParams(searchParams);
 
     const settings = useMemo(
         () => ({

--- a/modules/Head/components/DynamicPreviewBranding.tsx
+++ b/modules/Head/components/DynamicPreviewBranding.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useSessionStorageValue } from '@react-hookz/web';
+import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 
-import { useThemeSettingsWithPreview } from '@/hooks';
 import type { ThemeSettings } from 'theme-settings';
+import { parsePreviewSearchParams } from 'utils';
 
 import { BrandingSettings } from './BrandingSettings';
 
@@ -15,12 +16,15 @@ interface Props {
 }
 
 export function DynamicPreviewBranding({ settings }: Props) {
-    const themeSettings = useThemeSettingsWithPreview();
+    const searchParams = useSearchParams();
+    const parsedPreviewSettings = parsePreviewSearchParams(searchParams);
+
     const [previewSettings, setPreviewSettings] = useSessionStorageValue(STORAGE_KEY, {});
 
     useEffect(() => {
-        setPreviewSettings(themeSettings);
-    }, [setPreviewSettings, themeSettings]);
+        setPreviewSettings(parsedPreviewSettings);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [JSON.stringify(parsedPreviewSettings), setPreviewSettings]);
 
     if (Object.keys(previewSettings).length === 0) {
         return null;

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,4 +1,5 @@
 export { getUploadcareImage } from './getUploadcareImage';
 export { onPlainLeftClick } from './onPlainLeftClick';
 export { parseNumber } from './parseNumber';
+export { parsePreviewSearchParams } from './parsePreviewSearchParams';
 export { withoutUndefined } from './withoutUndefined';

--- a/utils/parsePreviewSearchParams.ts
+++ b/utils/parsePreviewSearchParams.ts
@@ -1,7 +1,8 @@
-import { withoutUndefined } from '@/utils';
 import type { Font, ThemeSettings } from 'theme-settings';
 
-export function parseSearchParams(searchParams: URLSearchParams): Partial<ThemeSettings> {
+import { withoutUndefined } from './withoutUndefined';
+
+export function parsePreviewSearchParams(searchParams: URLSearchParams): Partial<ThemeSettings> {
     let show_date: boolean | undefined;
     let show_featured_categories: boolean | undefined;
     let show_subtitle: boolean | undefined;


### PR DESCRIPTION
So, the problem here was that I was re-using the `useThemeSettingsWithPreview` hook which uses `useThemeSettings` which relies on context from `ThemeSettings`, but because `DynamicPreviewBranding` is rendered outside of `ThemeSettingsProvider`, it was injecting the default theme settings instead of the newsroom one's.