### PR TITLE
[CARE-5202] Feature - Hide cookie bar if mask parameter is present

### DIFF
--- a/components/PreviewPageMask/PreviewPageMask.tsx
+++ b/components/PreviewPageMask/PreviewPageMask.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { useSearchParams } from 'next/navigation';
+import { useMaskParam } from 'hooks';
 
 import styles from './PreviewPageMask.module.scss';
 
 export function PreviewPageMask() {
-    const searchParams = useSearchParams();
-    const mask = JSON.parse(searchParams.get('mask') || 'false');
+    const mask = useMaskParam();
 
     if (!mask) {
         return null;

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useDebounce } from './useDebounce';
 export { useDevice } from './useDevice';
+export { useMaskParam } from './useMaskParam';
 export { useThemeSettingsWithPreview } from './useThemeSettingsWithPreview';

--- a/hooks/useMaskParam.ts
+++ b/hooks/useMaskParam.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { useMemo } from 'react';
+
+export function useMaskParam(): boolean {
+    const searchParams = useSearchParams();
+    const mask = searchParams.get('mask');
+
+    return useMemo(() => {
+        if (!mask) {
+            return false;
+        }
+
+        try {
+            return Boolean(JSON.parse(mask));
+        } catch (_) {
+            return false;
+        }
+    }, [mask]);
+}

--- a/modules/CookieConsent/components/CookieConsentBar.tsx
+++ b/modules/CookieConsent/components/CookieConsentBar.tsx
@@ -7,6 +7,7 @@ import classNames from 'classnames';
 
 import { FormattedMessage, useLocale } from '@/adapters/client';
 import { Button } from '@/components/Button';
+import { useMaskParam } from 'hooks';
 
 import styles from './CookieConsentBar.module.scss';
 
@@ -16,6 +17,11 @@ interface Props {
 
 export function CookieConsentBar({ children }: Props) {
     const locale = useLocale();
+    const isHidden = useMaskParam();
+
+    if (isHidden) {
+        return null;
+    }
 
     return (
         <DefaultCookieConsentBar>


### PR DESCRIPTION
When live previewing the theme, we use the `mask` parameter to prevent clicking inside the page, but cookie consent bar could still appear.

With this change, the cookie bar will not be rendered.