### PR TITLE
[CARE-5201] Feature - Allow communication between the theme and the parent

### DIFF
--- a/app/[localeCode]/layout.tsx
+++ b/app/[localeCode]/layout.tsx
@@ -8,6 +8,7 @@ import { CategoryImageFallbackProvider } from '@/components/CategoryImage';
 import { PreviewPageMask } from '@/components/PreviewPageMask';
 import { ScrollToTopButton } from '@/components/ScrollToTopButton';
 import { StoryImageFallbackProvider } from '@/components/StoryImage';
+import { WindowScrollListener } from '@/components/WindowScrollListener';
 import { AnalyticsProvider } from '@/modules/Analytics';
 import { Boilerplate } from '@/modules/Boilerplate';
 import {
@@ -89,6 +90,7 @@ export default async function MainLayout({ children, params }: Props) {
                     <ScrollToTopButton />
                     <CookieConsent localeCode={localeCode} />
                     <PreviewPageMask />
+                    <WindowScrollListener />
                 </AppContext>
             </body>
         </html>

--- a/components/WindowScrollListener/WindowScrollListener.tsx
+++ b/components/WindowScrollListener/WindowScrollListener.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect } from 'react';
+
+type OnScrollMessage = {
+    type: 'onScroll';
+    value: number;
+};
+
+type ScrollToMessage = {
+    type: 'scrollTo';
+    value: number;
+};
+
+export function WindowScrollListener() {
+    useEffect(() => {
+        function onScroll() {
+            window.parent.postMessage(
+                {
+                    type: 'onScroll',
+                    value: window.scrollY,
+                } satisfies OnScrollMessage,
+                '*',
+            );
+        }
+
+        window.addEventListener('scroll', onScroll);
+
+        return () => window.removeEventListener('scroll', onScroll);
+    }, []);
+
+    useEffect(() => {
+        function onMessage(event: MessageEvent<ScrollToMessage>) {
+            if (event.data.type === 'scrollTo') {
+                window.scrollTo({ top: event.data.value });
+            }
+        }
+
+        window.addEventListener('message', onMessage);
+
+        return () => window.removeEventListener('message', onMessage);
+    }, []);
+
+    return null;
+}

--- a/components/WindowScrollListener/index.ts
+++ b/components/WindowScrollListener/index.ts
@@ -1,0 +1,1 @@
+export { WindowScrollListener } from './WindowScrollListener';


### PR DESCRIPTION
We need to be able to preserve the scroll position when live previewing the theme, but since it's not possible to access the scroll position of the iframe, we need this extra code to provide the scroll position when scrolling happens.

Similarly, we also need to listen to the messages from the parent so we can restore the scroll position after the iframe is reloaded.