### PR TITLE
[DEV-12308] Feature - Show a 404 page if category is empty

### DIFF
--- a/app/[localeCode]/category/[slug]/page.tsx
+++ b/app/[localeCode]/category/[slug]/page.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 async function resolve({ localeCode, slug }: Props['params']) {
     const translatedCategory = await app().translatedCategory(localeCode, slug);
-    if (!translatedCategory) notFound();
+    if (!translatedCategory || translatedCategory.public_stories_number === 0) notFound();
 
     const category = await app().category(translatedCategory.id);
     if (!category) notFound();


### PR DESCRIPTION
I think it doesn't make sense to show the category page if there's no stories published in it.