### PR TITLE
[CARE-5260][DEV-13053] Bump `@prezly/content-renderer-react-js` to `0.38.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@headlessui/react": "1.7.18",
         "@playwright/test": "^1.33.0",
         "@prezly/analytics-nextjs": "3.0.0",
-        "@prezly/content-renderer-react-js": "0.38.1",
+        "@prezly/content-renderer-react-js": "0.38.3",
         "@prezly/sdk": "21.6.0",
         "@prezly/story-content-format": "0.65.1",
         "@prezly/theme-kit-nextjs": "9.6.0",
@@ -2999,9 +2999,9 @@
       }
     },
     "node_modules/@prezly/content-renderer-react-js": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@prezly/content-renderer-react-js/-/content-renderer-react-js-0.38.1.tgz",
-      "integrity": "sha512-Z6WDS8mZGGk3AhBFOkFGc7PnacrFB65z0CPpYKwm+ApCN2Frc4aqDyVqhppK9P7G1kqEYn7jHj2npADYZh5w1A==",
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@prezly/content-renderer-react-js/-/content-renderer-react-js-0.38.3.tgz",
+      "integrity": "sha512-XafI2RhNJDs4F78MHcqHRYto/g5dWavaPNQRy4tKNLHZ44u+4zAvVJt4Agd0oZNc/x/ytdGXSRjkzYnxKKaDkA==",
       "dependencies": {
         "@prezly/linear-partition": "^1.0.2",
         "@prezly/sdk": "^21.6.0",
@@ -20668,9 +20668,9 @@
       }
     },
     "@prezly/content-renderer-react-js": {
-      "version": "0.38.1",
-      "resolved": "https://registry.npmjs.org/@prezly/content-renderer-react-js/-/content-renderer-react-js-0.38.1.tgz",
-      "integrity": "sha512-Z6WDS8mZGGk3AhBFOkFGc7PnacrFB65z0CPpYKwm+ApCN2Frc4aqDyVqhppK9P7G1kqEYn7jHj2npADYZh5w1A==",
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/@prezly/content-renderer-react-js/-/content-renderer-react-js-0.38.3.tgz",
+      "integrity": "sha512-XafI2RhNJDs4F78MHcqHRYto/g5dWavaPNQRy4tKNLHZ44u+4zAvVJt4Agd0oZNc/x/ytdGXSRjkzYnxKKaDkA==",
       "requires": {
         "@prezly/linear-partition": "^1.0.2",
         "@prezly/sdk": "^21.6.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@headlessui/react": "1.7.18",
     "@playwright/test": "^1.33.0",
     "@prezly/analytics-nextjs": "3.0.0",
-    "@prezly/content-renderer-react-js": "0.38.1",
+    "@prezly/content-renderer-react-js": "0.38.3",
     "@prezly/sdk": "21.6.0",
     "@prezly/story-content-format": "0.65.1",
     "@prezly/theme-kit-nextjs": "9.6.0",


### PR DESCRIPTION
I'll make sure to merge it once https://github.com/prezly/prezly/pull/14931 is merged. I'll update the rest of themes to new content renderer version, as I have to do it anyway :) So doing it as part of CARE-5260