### PR TITLE
[CARE-5671] Fix - Tweak staggered layout to show images properly

### DIFF
--- a/components/StaggeredLayout/StaggeredLayout.tsx
+++ b/components/StaggeredLayout/StaggeredLayout.tsx
@@ -2,13 +2,18 @@
 
 import classNames from 'classnames';
 import { Children, useMemo, useRef } from 'react';
-import type { PropsWithChildren } from 'react';
+import type { ReactNode } from 'react';
 
 import { useDevice } from '@/hooks';
 
 import styles from './StaggeredLayout.module.scss';
 
-export function StaggeredLayout({ children }: PropsWithChildren<{}>) {
+type Props = {
+    children: ReactNode;
+    className?: string;
+};
+
+export function StaggeredLayout({ children, className }: Props) {
     const isLayoutInitializedRef = useRef(false);
     const { isMobile, isTablet } = useDevice();
 
@@ -46,12 +51,12 @@ export function StaggeredLayout({ children }: PropsWithChildren<{}>) {
     }, [children, columnCount]);
 
     if (!isLayoutInitializedRef.current) {
-        return <div>{children}</div>;
+        return <div className={className}>{children}</div>;
     }
 
     return (
         <div
-            className={classNames(styles.container, {
+            className={classNames(styles.container, className, {
                 [styles.desktop]: columnCount === 3,
             })}
         >

--- a/components/StoryCards/StoryCard.module.scss
+++ b/components/StoryCards/StoryCard.module.scss
@@ -6,10 +6,6 @@ $spacing-card: $spacing-4 - $spacing-half; // 1.25rem = 20px That's the only hac
 
     /* stylelint-disable-next-line order/order */
     @include desktop-up {
-        &:not(:last-of-type) {
-            margin-bottom: 0;
-        }
-
         &:hover .image {
             transform: scale(1.05);
         }
@@ -175,6 +171,12 @@ $spacing-card: $spacing-4 - $spacing-half; // 1.25rem = 20px That's the only hac
 .big {
     .imageWrapper {
         @include big-card-aspect-ratio;
+    }
+}
+
+.withStaticImage {
+    .imageWrapper {
+        aspect-ratio: unset;
     }
 }
 

--- a/components/StoryCards/StoryCard.tsx
+++ b/components/StoryCards/StoryCard.tsx
@@ -15,13 +15,22 @@ import { StoryImage } from '../StoryImage';
 import styles from './StoryCard.module.scss';
 
 type Props = {
-    story: ListStory;
-    size?: 'small' | 'medium' | 'big';
+    className?: string;
     showDate: boolean;
     showSubtitle: boolean;
+    size?: 'small' | 'medium' | 'big';
+    story: ListStory;
+    withStaticImage?: boolean;
 };
 
-export function StoryCard({ story, size = 'small', showDate, showSubtitle }: Props) {
+export function StoryCard({
+    className,
+    showDate,
+    showSubtitle,
+    size = 'small',
+    story,
+    withStaticImage = false,
+}: Props) {
     const { categories, title, subtitle } = story;
     const localeCode = useLocale();
     const { isTablet } = useDevice(); // TODO: It would be more performant if done with pure CSS
@@ -37,10 +46,11 @@ export function StoryCard({ story, size = 'small', showDate, showSubtitle }: Pro
 
     return (
         <div
-            className={classNames(styles.container, {
+            className={classNames(styles.container, className, {
                 [styles.small]: size === 'small',
                 [styles.medium]: size === 'medium',
                 [styles.big]: size === 'big',
+                [styles.withStaticImage]: withStaticImage,
             })}
         >
             <Link
@@ -53,6 +63,7 @@ export function StoryCard({ story, size = 'small', showDate, showSubtitle }: Pro
                     size={size}
                     className={styles.image}
                     placeholderClassName={styles.placeholder}
+                    isStatic={withStaticImage}
                 />
             </Link>
             <div className={styles.content}>

--- a/components/StoryImage/StoryImage.module.scss
+++ b/components/StoryImage/StoryImage.module.scss
@@ -15,6 +15,10 @@
     @include branding;
 
     object-fit: cover;
+
+    &.static {
+        position: static !important;
+    }
 }
 
 .imageContainer {

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -12,13 +12,20 @@ import { type CardSize, getCardImageSizes, getStoryThumbnail } from './lib';
 import styles from './StoryImage.module.scss';
 
 type Props = {
-    story: Pick<ListStory, 'title' | 'thumbnail_image'>;
-    size: CardSize;
     className?: string;
+    isStatic?: boolean;
     placeholderClassName?: string;
+    size: CardSize;
+    story: Pick<ListStory, 'title' | 'thumbnail_image'>;
 };
 
-export function StoryImage({ story, size, className, placeholderClassName }: Props) {
+export function StoryImage({
+    className,
+    isStatic = false,
+    placeholderClassName,
+    size,
+    story,
+}: Props) {
     const fallback = useFallback();
     const image = getStoryThumbnail(story);
     const uploadcareImage = getUploadcareImage(image);
@@ -29,7 +36,9 @@ export function StoryImage({ story, size, className, placeholderClassName }: Pro
                 <UploadcareImage
                     fill
                     alt={story.title}
-                    className={styles.image}
+                    className={classNames(styles.image, {
+                        [styles.static]: isStatic,
+                    })}
                     src={uploadcareImage.cdnUrl}
                     sizes={getCardImageSizes(size)}
                 />

--- a/modules/InfiniteStories/StoriesList.module.scss
+++ b/modules/InfiniteStories/StoriesList.module.scss
@@ -40,3 +40,13 @@
     color: $color-base-500;
     margin: 0;
 }
+
+.staggered {
+    .card {
+        margin-bottom: $spacing-8;
+
+        @include mobile-only {
+            margin-bottom: $spacing-7;
+        }
+    }
+}

--- a/modules/InfiniteStories/StoriesList.tsx
+++ b/modules/InfiniteStories/StoriesList.tsx
@@ -104,14 +104,16 @@ export function StoriesList({
                 </div>
             )}
             {restStories.length > 0 && layout === 'masonry' && (
-                <StaggeredLayout>
+                <StaggeredLayout className={styles.staggered}>
                     {restStories.map((story) => (
                         <StoryCard
                             key={story.uuid}
+                            className={styles.card}
                             story={story}
                             size="medium"
                             showDate={showDate}
                             showSubtitle={showSubtitle}
+                            withStaticImage
                         />
                     ))}
                 </StaggeredLayout>


### PR DESCRIPTION
A follow-up to #1164 since I've noticed the cards are not displayed the same way as in Greta theme, which we're trying to emulate.

![Screenshot 2024-07-04 at 15 18 10](https://github.com/prezly/theme-nextjs-bea/assets/4209081/b59b3840-187a-49fd-8ead-6bbf6b39a045)
