### PR TITLE
Fix - Set font size to 0 to prevent border overflow

### DIFF
--- a/components/StoryCards/StoryCard.module.scss
+++ b/components/StoryCards/StoryCard.module.scss
@@ -28,6 +28,7 @@ $spacing-card: $spacing-4 - $spacing-half; // 1.25rem = 20px That's the only hac
     overflow: hidden;
     text-decoration: none;
     border: 1px solid $color-borders;
+    font-size: 0;
 
     @include desktop-up {
         .image {


### PR DESCRIPTION
With the masonry layout, I've noticed that cards have a weird empty space below the image which makes the border stand out.

Resetting font size to 0 in the container makes it look correct.

![Screenshot 2024-07-04 at 16 04 13](https://github.com/prezly/theme-nextjs-bea/assets/4209081/3d77f133-be05-41ce-8e2e-0b2434b7d24c)
![Screenshot 2024-07-04 at 16 04 21](https://github.com/prezly/theme-nextjs-bea/assets/4209081/8328e75f-0f0f-49c3-9fed-d49e580f8aca)
