### PR TITLE
Fix - Use 1.5 aspect ratio for placeholders in staggered layout

### DIFF
--- a/components/StoryImage/StoryImage.module.scss
+++ b/components/StoryImage/StoryImage.module.scss
@@ -35,6 +35,10 @@
     align-items: center;
     justify-content: center;
     padding: $spacing-4;
+
+    &.static {
+        aspect-ratio: 1.5;
+    }
 }
 
 .placeholderLogo {

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -49,7 +49,11 @@ export function StoryImage({
     const fallbackImage = getUploadcareImage(fallback.image);
 
     return (
-        <span className={classNames(styles.placeholder, placeholderClassName)}>
+        <span
+            className={classNames(styles.placeholder, placeholderClassName, {
+                [styles.static]: isStatic,
+            })}
+        >
             {fallbackImage ? (
                 <UploadcareImage
                     alt="No image"


### PR DESCRIPTION
Added fixed aspect ratio on stories without image, so the masonry layout is more obvious, otherwise if there's a lot of stories without a cover image, it looks very similar to the regular grid layout.

Before
<img width="1249" alt="Screenshot 2024-07-04 at 18 31 35" src="https://github.com/prezly/theme-nextjs-bea/assets/4209081/726fd23a-4f5a-4eda-b2e6-245915e8bd42">

After
<img width="1249" alt="Screenshot 2024-07-04 at 18 31 59" src="https://github.com/prezly/theme-nextjs-bea/assets/4209081/d323c333-1d81-44ba-85b6-1a15d30da27e">
