### PR TITLE
[DEV-13405] Display story date in full width featured story

### DIFF
--- a/components/StoryCards/HighlightedStoryCard.module.scss
+++ b/components/StoryCards/HighlightedStoryCard.module.scss
@@ -135,3 +135,9 @@
         font-size: $font-size-m;
     }
 }
+
+.date {
+    margin-top: $spacing-2;
+    color: var(--prezly-white);
+    line-height: 160%;
+}

--- a/components/StoryCards/HighlightedStoryCard.module.scss
+++ b/components/StoryCards/HighlightedStoryCard.module.scss
@@ -59,11 +59,11 @@
 }
 
 .content {
-    padding: $spacing-8 $spacing-4;
+    padding: $spacing-7 $spacing-4;
     z-index: 2;
 
     @include tablet-up {
-        padding: $spacing-8 $spacing-5;
+        padding: $spacing-7 $spacing-5;
     }
 
     @include desktop-up {

--- a/components/StoryCards/HighlightedStoryCard.tsx
+++ b/components/StoryCards/HighlightedStoryCard.tsx
@@ -3,7 +3,7 @@
 import { Category } from '@prezly/sdk';
 import classNames from 'classnames';
 
-import { useLocale } from '@/adapters/client';
+import { FormattedDate, useLocale } from '@/adapters/client';
 import type { ListStory } from 'types';
 
 import { Badge } from '../Badge';
@@ -24,7 +24,7 @@ type Props = {
 
 export function HighlightedStoryCard({ fullWidth, rounded, showDate, showSubtitle, story }: Props) {
     const locale = useLocale();
-    const { categories, slug, subtitle } = story;
+    const { categories, published_at, slug, subtitle } = story;
 
     const translatedCategories = Category.translations(categories, locale);
 
@@ -76,6 +76,11 @@ export function HighlightedStoryCard({ fullWidth, rounded, showDate, showSubtitl
                         </Link>
                     </h2>
                     {showSubtitle && subtitle && <p className={styles.subtitle}>{subtitle}</p>}
+                    {showDate && published_at && (
+                        <div className={styles.date}>
+                            <FormattedDate value={published_at} />
+                        </div>
+                    )}
                 </div>
             </div>
         );


### PR DESCRIPTION
- also noticed the vertical paddings on mobile and tablet were using desktop numbers, so I've tweaked that

<img width="1259" alt="Screenshot 2024-08-23 at 14 33 33" src="https://github.com/user-attachments/assets/57370a3b-1773-41b6-9825-53efdc746c23">
