### PR TITLE
[CARE-6113] Feature - Change Bea footer links to use an underline

### DIFF
--- a/modules/Boilerplate/ui/Boilerplate.module.scss
+++ b/modules/Boilerplate/ui/Boilerplate.module.scss
@@ -73,5 +73,5 @@
 .link,
 .about a {
     color: var(--prezly-footer-text-color);
-    text-decoration: none;
+    text-decoration: underline;
 }

--- a/modules/Footer/ui/Footer.module.scss
+++ b/modules/Footer/ui/Footer.module.scss
@@ -35,7 +35,7 @@
     border: 0;
     cursor: pointer;
     color: var(--prezly-footer-text-color);
-    text-decoration: none;
+    text-decoration: underline;
 
     & + & {
         margin-left: $spacing-3;


### PR DESCRIPTION
<img width="1713" alt="image" src="https://github.com/user-attachments/assets/6f9b46c0-7169-48e1-8c60-99d451e25df6">
