### PR TITLE
[CARE-5657] Fix - Crop to aspect ratio before passing to the renderer

### DIFF
--- a/components/StoryCards/StoryCard.tsx
+++ b/components/StoryCards/StoryCard.tsx
@@ -13,6 +13,7 @@ import styles from './StoryCard.module.scss';
 
 type Props = {
     className?: string;
+    forceAspectRatio?: boolean;
     layout: 'horizontal' | 'vertical';
     publishedAt: string | null;
     showDate: boolean;
@@ -30,6 +31,7 @@ type Props = {
 
 export function StoryCard({
     className,
+    forceAspectRatio,
     layout,
     publishedAt,
     showDate,
@@ -64,8 +66,8 @@ export function StoryCard({
                 title={titleAsString}
             >
                 <StoryImage
-                    aspectRatio={4 / 3}
                     className={styles.image}
+                    forceAspectRatio={forceAspectRatio ? 4 / 3 : undefined}
                     isStatic={withStaticImage}
                     placeholderClassName={styles.placeholder}
                     size={size}

--- a/components/StoryCards/StoryCard.tsx
+++ b/components/StoryCards/StoryCard.tsx
@@ -64,6 +64,7 @@ export function StoryCard({
                 title={titleAsString}
             >
                 <StoryImage
+                    aspectRatio={4 / 3}
                     className={styles.image}
                     isStatic={withStaticImage}
                     placeholderClassName={styles.placeholder}

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -87,13 +87,13 @@ function applyAspectRatio(
     if (actualAspectRatio > aspectRatio) {
         const [width, height] = constrain(Math.round(image.height * aspectRatio), image.height);
         // The image is wider than it should
-        return image.smartCrop(width, height, 'smart', 'center');
+        return image.scaleCrop(width, height, true);
     }
 
     if (actualAspectRatio < aspectRatio) {
         // The image is taller than it should
         const [width, height] = constrain(image.width, Math.round(image.width / aspectRatio));
-        return image.smartCrop(width, height, 'smart', 'center');
+        return image.scaleCrop(width, height, true);
     }
 
     return image;

--- a/components/StoryImage/StoryImage.tsx
+++ b/components/StoryImage/StoryImage.tsx
@@ -44,7 +44,7 @@ export function StoryImage({
                     className={classNames(styles.image, {
                         [styles.static]: isStatic,
                     })}
-                    src={withSmartCrop(uploadcareImage.cdnUrl)}
+                    src={uploadcareImage.cdnUrl}
                     sizes={getCardImageSizes(size)}
                 />
             </div>
@@ -87,13 +87,13 @@ function applyAspectRatio(
     if (actualAspectRatio > aspectRatio) {
         const [width, height] = constrain(Math.round(image.height * aspectRatio), image.height);
         // The image is wider than it should
-        return image.scaleCrop(width, height, true);
+        return image.smartCrop(width, height, 'smart', 'center');
     }
 
     if (actualAspectRatio < aspectRatio) {
         // The image is taller than it should
         const [width, height] = constrain(image.width, Math.round(image.width / aspectRatio));
-        return image.scaleCrop(width, height, true);
+        return image.smartCrop(width, height, 'smart', 'center');
     }
 
     return image;
@@ -113,12 +113,4 @@ function constrain(width: number, height: number): [number, number] {
         Math.min(MAX_SCALED_SIZE, Math.round((width / height) * MAX_SCALED_SIZE)),
         Math.min(MAX_SCALED_SIZE, Math.round((height / width) * MAX_SCALED_SIZE)),
     ];
-}
-
-/**
- * TODO: Add smart cropping option to the @prezly/uploadcare package.
- * @see https://github.com/prezly/uploadcare/pull/12
- */
-function withSmartCrop(cdnUrl: string): string {
-    return cdnUrl.replace(/\/scale_crop\/(\d+x\d+)\/center\//, '/scale_crop/$1/smart/');
 }

--- a/modules/InfiniteStories/StoriesList.tsx
+++ b/modules/InfiniteStories/StoriesList.tsx
@@ -113,6 +113,7 @@ export function StoriesList({
                     {restStories.map((story, index) => (
                         <StoryCard
                             key={story.uuid}
+                            forceAspectRatio
                             layout="vertical"
                             publishedAt={story.published_at}
                             showDate={showDate}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@prezly/sdk": "21.12.0",
         "@prezly/story-content-format": "0.65.1",
         "@prezly/theme-kit-nextjs": "9.7.0",
-        "@prezly/uploadcare": "2.4.4",
+        "@prezly/uploadcare": "2.5.0",
         "@prezly/uploadcare-image": "0.3.2",
         "@react-hookz/web": "14.7.1",
         "@sentry/nextjs": "7.98.0",
@@ -3157,6 +3157,26 @@
         "@prezly/sdk": "21.12.0"
       }
     },
+    "node_modules/@prezly/theme-kit-core/node_modules/@prezly/uploadcare": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@prezly/uploadcare/-/uploadcare-2.4.4.tgz",
+      "integrity": "sha512-NMBMvrgBbhcuD/cdoIykiv8/v7l85yn9yVpXPYdXy26eB4aiFJY7JradDzWwm28dy9VM7jGKaQDeB0wxlOWHpw==",
+      "dependencies": {
+        "@prezly/progress-promise": "^2.0.1",
+        "@prezly/uploadcare-widget": "^3.16.1",
+        "@prezly/uploads": "^0.3.2",
+        "lodash.clamp": "^4.0.3",
+        "sanitize-filename": "^1.6.3"
+      }
+    },
+    "node_modules/@prezly/theme-kit-core/node_modules/@prezly/uploads": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@prezly/uploads/-/uploads-0.3.2.tgz",
+      "integrity": "sha512-bUIRPKC8bfjJgmKFG9T4CZssAb1jZu9XrYBQX3vgXOmN6ot+mK2rMwm0Lp7guUS4xMKvrnDAqz6si360RUCDCA==",
+      "dependencies": {
+        "is-plain-object": "^5.0.0"
+      }
+    },
     "node_modules/@prezly/theme-kit-intl": {
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/@prezly/theme-kit-intl/-/theme-kit-intl-9.6.0.tgz",
@@ -3217,9 +3237,9 @@
       }
     },
     "node_modules/@prezly/uploadcare": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@prezly/uploadcare/-/uploadcare-2.4.4.tgz",
-      "integrity": "sha512-NMBMvrgBbhcuD/cdoIykiv8/v7l85yn9yVpXPYdXy26eB4aiFJY7JradDzWwm28dy9VM7jGKaQDeB0wxlOWHpw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@prezly/uploadcare/-/uploadcare-2.5.0.tgz",
+      "integrity": "sha512-3zflwwqJ87Wadm2zBbIsDoxpCeqpgKqDPWjB0D4d9qZVr6nK9GBV6aMfqtqevsdGoyrtLbmGKWcjOh+p5cMD+g==",
       "dependencies": {
         "@prezly/progress-promise": "^2.0.1",
         "@prezly/uploadcare-widget": "^3.16.1",
@@ -20836,6 +20856,28 @@
         "@technically/omit-undefined": "^1.0.2",
         "parse-data-url": "^6.0.0",
         "url-pattern": "^1.0.3"
+      },
+      "dependencies": {
+        "@prezly/uploadcare": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/@prezly/uploadcare/-/uploadcare-2.4.4.tgz",
+          "integrity": "sha512-NMBMvrgBbhcuD/cdoIykiv8/v7l85yn9yVpXPYdXy26eB4aiFJY7JradDzWwm28dy9VM7jGKaQDeB0wxlOWHpw==",
+          "requires": {
+            "@prezly/progress-promise": "^2.0.1",
+            "@prezly/uploadcare-widget": "^3.16.1",
+            "@prezly/uploads": "^0.3.2",
+            "lodash.clamp": "^4.0.3",
+            "sanitize-filename": "^1.6.3"
+          }
+        },
+        "@prezly/uploads": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@prezly/uploads/-/uploads-0.3.2.tgz",
+          "integrity": "sha512-bUIRPKC8bfjJgmKFG9T4CZssAb1jZu9XrYBQX3vgXOmN6ot+mK2rMwm0Lp7guUS4xMKvrnDAqz6si360RUCDCA==",
+          "requires": {
+            "is-plain-object": "^5.0.0"
+          }
+        }
       }
     },
     "@prezly/theme-kit-intl": {
@@ -20870,9 +20912,9 @@
       }
     },
     "@prezly/uploadcare": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@prezly/uploadcare/-/uploadcare-2.4.4.tgz",
-      "integrity": "sha512-NMBMvrgBbhcuD/cdoIykiv8/v7l85yn9yVpXPYdXy26eB4aiFJY7JradDzWwm28dy9VM7jGKaQDeB0wxlOWHpw==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@prezly/uploadcare/-/uploadcare-2.5.0.tgz",
+      "integrity": "sha512-3zflwwqJ87Wadm2zBbIsDoxpCeqpgKqDPWjB0D4d9qZVr6nK9GBV6aMfqtqevsdGoyrtLbmGKWcjOh+p5cMD+g==",
       "requires": {
         "@prezly/progress-promise": "^2.0.1",
         "@prezly/uploadcare-widget": "^3.16.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@prezly/sdk": "21.12.0",
     "@prezly/story-content-format": "0.65.1",
     "@prezly/theme-kit-nextjs": "9.7.0",
-    "@prezly/uploadcare": "2.4.4",
+    "@prezly/uploadcare": "2.5.0",
     "@prezly/uploadcare-image": "0.3.2",
     "@react-hookz/web": "14.7.1",
     "@sentry/nextjs": "7.98.0",


### PR DESCRIPTION
See https://linear.app/prezly/issue/CARE-5657/innogames-blurry-cover-images-in-home-site-for-stories-published#comment-92259c27


# BEFORE


https://github.com/user-attachments/assets/0f5793f7-268f-4e53-94e6-c38c80e15230



# AFTER


https://github.com/user-attachments/assets/51ac7dad-9ccb-4e98-ad41-b62afbcacdd4

