### PR TITLE
[DEV-19797] Fix - Search widget fixes

### DIFF
--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -47,6 +47,7 @@ export function Modal({
                     >
                         <DialogBackdrop
                             className={classNames(styles.backdrop, backdropClassName)}
+                            onClick={onClose}
                         />
                     </TransitionChild>
 

--- a/modules/Header/ui/SearchWidget/components/SearchHit.tsx
+++ b/modules/Header/ui/SearchWidget/components/SearchHit.tsx
@@ -1,4 +1,5 @@
 import type { Search } from '@prezly/theme-kit-nextjs';
+import type { MouseEvent } from 'react';
 import type { Hit } from 'react-instantsearch-core';
 import { Highlight } from 'react-instantsearch-dom';
 
@@ -9,7 +10,7 @@ import styles from './SearchHit.module.scss';
 
 interface Props {
     hit: Hit<{ attributes: Search.IndexedStory }>;
-    onClick?: () => void;
+    onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
 }
 
 export function SearchHit({ hit, onClick }: Props) {

--- a/modules/Header/ui/SearchWidget/components/SearchResults.tsx
+++ b/modules/Header/ui/SearchWidget/components/SearchResults.tsx
@@ -27,7 +27,7 @@ export function SearchResults({ searchResults, query, isSearchPage, onClose }: P
     const totalResults = searchResults?.nbHits ?? 0;
 
     const Hit = useCallback<typeof SearchHit>(
-        ({ hit }) => <SearchHit onClick={() => onPlainLeftClick(onClose)} hit={hit} />,
+        ({ hit }) => <SearchHit onClick={onPlainLeftClick(onClose)} hit={hit} />,
         [onClose],
     );
 


### PR DESCRIPTION
- clicking the backdrop now closes the search
- fixed `onClick` handler on `SearchHit` component