### PR TITLE
[DEV-19988] Fix - attachment card with long name breaking responsive design

### DIFF
--- a/components/ContentRenderer/components/Attachment/Attachment.module.scss
+++ b/components/ContentRenderer/components/Attachment/Attachment.module.scss
@@ -35,6 +35,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+
+    @include not-desktop {
+        white-space: normal;
+    }
 }
 
 .meta {


### PR DESCRIPTION
<img width="450" alt="image" src="https://github.com/user-attachments/assets/5c1e15a0-0fc9-4f19-8bd3-c383b7302c95" />
