### PR TITLE
[DEV-20186] Fix styles of in-raw-HTML tables

### DIFF
--- a/src/components/RichText/styles.module.scss
+++ b/src/components/RichText/styles.module.scss
@@ -138,9 +138,46 @@
 
 .htmlContent table {
     width: 100% !important; // need to be specified because there is a default style from renderer
+    max-width: 100%;
     text-indent: 0;
+    table-layout: auto;
     border-collapse: collapse;
-    border-color: inherit;
+
+    margin-top: $spacing-2;
+    margin-bottom: $spacing-2;
+
+    border-color: var(--prezly-border-color);
+
+    th {
+        background: var(--prezly-background-color-tertiary);
+
+        > p {
+            font-weight: 600;
+        }
+    }
+
+    th, td {
+        color: var(--prezly-text-color);
+        border-color: var(--prezly-border-color);
+        font-size: 95%;
+
+        min-width: 40px;
+        min-height: 40px;
+
+        padding: $spacing-1 * 1.5;
+
+        text-align: left;
+        vertical-align: middle;
+        word-break: keep-all;
+
+        > *:first-child {
+            margin-top: 0;
+        }
+
+        > *:last-child {
+            margin-bottom: 0;
+        }
+    }
 }
 
 .htmlContent blockquote {


### PR DESCRIPTION
Before the change, the styles were relying on browser defaults. 

- Which was inconsistent
- Did not take into account background color, and could made the borders practically invisible for certain configurations
- Lacked in-cells and bottom spacing

BEFORE: 

![Screenshot From 2025-04-22 16-16-50](https://github.com/user-attachments/assets/04a39b05-763b-4c40-8c44-62572d62e200)

![Screenshot From 2025-04-22 16-17-50](https://github.com/user-attachments/assets/47001c87-aa4e-49a1-9ef0-5f2583cfa411)

AFTER:
![Screenshot From 2025-04-22 16-16-04](https://github.com/user-attachments/assets/60ff662c-9e86-4e4e-a7c0-3172c707d894)
