### PR TITLE
[DEV-20187] Fix - Multiple h1 tags on pages

### DIFF
--- a/src/modules/Header/ui/Header.tsx
+++ b/src/modules/Header/ui/Header.tsx
@@ -181,13 +181,13 @@ export function Header({
                                 [styles.withoutLogo]: !logo,
                             })}
                         >
-                            <h1
+                            <div
                                 className={classNames(styles.title, {
                                     [styles.hidden]: logo,
                                 })}
                             >
                                 {newsroomName}
-                            </h1>
+                            </div>
                             <Logo image={logo} size={logoSize} />
                         </Link>
 


### PR DESCRIPTION
Use non-h1 tag for the site logo

Otherwise all pages have 2 h1 tags on them.

See https://linear.app/prezly/issue/OPS-590/rac-seo-questions-after-migration#heading-2-multiple-h1s-per-page-see-als-response-below-687410bd