### PR TITLE
[DEV-20438] Fix - Sort year filter in descending order

### DIFF
--- a/src/modules/Search/components/Facet.tsx
+++ b/src/modules/Search/components/Facet.tsx
@@ -22,9 +22,16 @@ export const Facet = connectRefinementList(
         const visibleItems = useMemo(
             () =>
                 items
-                    .sort((a, b) => a.label.localeCompare(b.label))
+                    .slice()
+                    .sort((a, b) => {
+                        if (attribute === 'attributes.year') {
+                            return b.label.localeCompare(a.label);
+                        }
+
+                        return a.label.localeCompare(b.label);
+                    })
                     .slice(0, isExtended ? undefined : DEFAULT_FACETS_LIMIT),
-            [isExtended, items],
+            [attribute, isExtended, items],
         );
 
         function toggleList() {


### PR DESCRIPTION
![Screenshot 2025-05-14 at 15 31 05](https://github.com/user-attachments/assets/596bf897-f100-4d13-8baf-140c516983de)
