### PR TITLE
Fix - Properly hide filters and other search page tweaks

### DIFF
--- a/src/modules/Search/components/Results.module.scss
+++ b/src/modules/Search/components/Results.module.scss
@@ -10,6 +10,10 @@
     font-weight: 400;
     color: $color-base-500;
 
+    @include mobile-only {
+        padding-top: 0;
+    }
+
     @include desktop-up {
         grid-column: span 3;
     }

--- a/src/modules/Search/components/SearchBar.tsx
+++ b/src/modules/Search/components/SearchBar.tsx
@@ -37,7 +37,7 @@ export function SearchBar() {
                 <div className={styles.header}>
                     <SearchInput />
                 </div>
-                {isMobile && (
+                {isMobile && hasFacets && (
                     <Button
                         variation="navigation"
                         icon={IconMenu}
@@ -47,21 +47,16 @@ export function SearchBar() {
                         <FormattedMessage locale={locale} for={translations.search.filters} />
                     </Button>
                 )}
-                {hasFacets && (
-                    <div className={classNames(styles.facets, { [styles.facetsOpen]: isShown })}>
+                <div className={classNames(styles.facets, { [styles.facetsOpen]: isShown })}>
+                    {hasFacets && (
                         <p className={styles.filters}>
                             <FormattedMessage locale={locale} for={translations.search.filters} />
                         </p>
-                        {AVAILABLE_FACET_ATTRIBUTES.map((attribute) => (
-                            <Facet
-                                key={attribute}
-                                attribute={attribute}
-                                showMore
-                                showMoreLimit={50}
-                            />
-                        ))}
-                    </div>
-                )}
+                    )}
+                    {AVAILABLE_FACET_ATTRIBUTES.map((attribute) => (
+                        <Facet key={attribute} attribute={attribute} showMore showMoreLimit={50} />
+                    ))}
+                </div>
             </div>
         </div>
     );

--- a/src/modules/Search/components/Subtitle.tsx
+++ b/src/modules/Search/components/Subtitle.tsx
@@ -21,20 +21,18 @@ export function Subtitle() {
 
     return (
         <p className={styles.subtitle}>
-            {searchQuery ? (
-                <FormattedMessage
-                    locale={locale}
-                    for={translations.search.fullResultsSubTitle}
-                    values={{
-                        resultsCount: <b>{resultsCount}</b>,
-                        searchQuery: (
-                            <>
-                                &quot;<b>{searchQuery}</b>&quot;
-                            </>
-                        ),
-                    }}
-                />
-            ) : undefined}
+            <FormattedMessage
+                locale={locale}
+                for={translations.search.fullResultsSubTitle}
+                values={{
+                    resultsCount: <b>{resultsCount}</b>,
+                    searchQuery: (
+                        <>
+                            &quot;<b>{searchQuery}</b>&quot;
+                        </>
+                    ),
+                }}
+            />
         </p>
     );
 }

--- a/src/modules/Search/components/Subtitle.tsx
+++ b/src/modules/Search/components/Subtitle.tsx
@@ -15,7 +15,7 @@ export function Subtitle() {
     const { query: searchQuery } = searchState;
     const resultsCount = searchResults ? searchResults.nbHits : 0;
 
-    if (resultsCount === 0) {
+    if (resultsCount === 0 || !searchQuery) {
         return null;
     }
 


### PR DESCRIPTION
So turns out the Facet components must be rendered otherwise the attributes won't get sent to Meilisearch and then we can't detect if there's any available facets or not.

Other tweaks include:
- removed subtitle if there's no search query (previously was rendering an empty container)
- removed top padding in empty state on mobile