### PR TITLE
[DEV-20594] Fix - Do not fetch extra story on homepage in hub sites

### DIFF
--- a/app/[localeCode]/(index)/page.tsx
+++ b/app/[localeCode]/(index)/page.tsx
@@ -64,7 +64,9 @@ export default async function StoriesIndexPage(props: Props) {
                 <HubStories
                     layout={themeSettings.layout}
                     localeCode={params.localeCode}
-                    pageSize={getStoryListPageSize(themeSettings.layout)}
+                    // we're subtracting one story because there's no highlighted
+                    // story in hub sites
+                    pageSize={getStoryListPageSize(themeSettings.layout) - 1}
                     showDate={themeSettings.show_date}
                     showSubtitle={themeSettings.show_subtitle}
                     storyCardVariant={themeSettings.story_card_variant}


### PR DESCRIPTION
Because there is no highlighted story for hubs, we don't need to fetch an extra story.