### PR TITLE
[DEV-20679] Bump the content renderer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@meilisearch/instant-meilisearch": "0.26.0",
     "@playwright/test": "^1.50.1",
     "@prezly/analytics-nextjs": "4.3.0",
-    "@prezly/content-renderer-react-js": "0.41.2",
+    "@prezly/content-renderer-react-js": "0.41.3",
     "@prezly/sdk": "23.17.0",
     "@prezly/story-content-format": "0.68.0",
     "@prezly/theme-kit-nextjs": "10.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0(react@19.0.0)
       '@prezly/content-renderer-react-js':
-        specifier: 0.41.2
-        version: 0.41.2(js-cookie@3.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 0.41.3
+        version: 0.41.3(js-cookie@3.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@prezly/sdk':
         specifier: 23.17.0
         version: 23.17.0
@@ -1561,8 +1561,8 @@ packages:
   '@prezly/content-format@0.68.0':
     resolution: {integrity: sha512-7S5rgscnnhJfVyAiPJob8sT4RHQ1O2LUo60xQBz2OX+V01nTmm9wSiqbVx+/nP1OkWezH6EusNbP+3PdMYgE4w==}
 
-  '@prezly/content-renderer-react-js@0.41.2':
-    resolution: {integrity: sha512-qqF2ykcmLNN2zL1gtZqGTpvHaGq2Vw25b5iZL9iSg78tQ6EFAxdw0qRksWfDjCk6W3OupS6m0lVVfcSeE8Ux7Q==}
+  '@prezly/content-renderer-react-js@0.41.3':
+    resolution: {integrity: sha512-h+vOdhQ1GScaww65QLyl8lbTRZBbmWyw0pUumvsrXmSXxPSTIIxCBGablYZLSktOrgIGujZlU9cbdJE3rx7uww==}
     peerDependencies:
       react: '18'
       react-dom: '18'
@@ -7006,7 +7006,7 @@ snapshots:
       '@prezly/uploads': 0.2.1
       is-plain-object: 5.0.0
 
-  '@prezly/content-renderer-react-js@0.41.2(js-cookie@3.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@prezly/content-renderer-react-js@0.41.3(js-cookie@3.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@prezly/linear-partition': 1.0.3
       '@prezly/sdk': 23.17.0
@@ -7031,8 +7031,8 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3)
       '@typescript-eslint/parser': 8.25.0(eslint@9.24.0)(typescript@5.8.3)
       eslint: 9.24.0
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0))(eslint@9.24.0)
-      eslint-config-airbnb-typescript: 18.0.0(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3))(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0))(eslint@9.24.0)
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.24.0))(eslint@9.24.0)
+      eslint-config-airbnb-typescript: 18.0.0(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3))(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.24.0))(eslint@9.24.0)
       eslint-config-prettier: 9.1.0(eslint@9.24.0)
       eslint-import-resolver-typescript: 3.8.3(eslint-plugin-import@2.31.0)(eslint@9.24.0)
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.24.0)
@@ -8698,7 +8698,7 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0))(eslint@9.24.0):
+  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.24.0))(eslint@9.24.0):
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 9.24.0
@@ -8707,12 +8707,12 @@ snapshots:
       object.entries: 1.1.8
       semver: 6.3.1
 
-  eslint-config-airbnb-typescript@18.0.0(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3))(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0))(eslint@9.24.0):
+  eslint-config-airbnb-typescript@18.0.0(@typescript-eslint/eslint-plugin@8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3))(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.24.0))(eslint@9.24.0):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.25.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0)(typescript@5.8.3)
       '@typescript-eslint/parser': 8.25.0(eslint@9.24.0)(typescript@5.8.3)
       eslint: 9.24.0
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint@9.24.0))(eslint@9.24.0)
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.25.0(eslint@9.24.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.8.3)(eslint@9.24.0))(eslint@9.24.0)
     transitivePeerDependencies:
       - eslint-plugin-import
 


### PR DESCRIPTION
To include this fix: https://github.com/prezly/content-renderer-react-js/pull/99