### PR TITLE
[DEV-20721] Fix - Update URL with the updated state not the current one when searching

### DIFF
--- a/src/modules/Search/Search.tsx
+++ b/src/modules/Search/Search.tsx
@@ -62,7 +62,7 @@ export function Search({
 
     function onSearchStateChange(updatedSearchState: SearchState) {
         setSearchState(updatedSearchState);
-        scheduleUrlUpdate(searchState);
+        scheduleUrlUpdate(updatedSearchState);
     }
 
     return (


### PR DESCRIPTION
This is probably not enough to fix the search. The bug only occurs in production so it's a bit hard to debug.