### PR TITLE
[DEV-20684] Fix - Always render H1 on homepage

### DIFF
--- a/src/modules/InfiniteHubStories/InfiniteHubStories.module.scss
+++ b/src/modules/InfiniteHubStories/InfiniteHubStories.module.scss
@@ -33,6 +33,10 @@
 
 .title {
     margin-bottom: $spacing-7;
+
+    &.aria {
+        @include sr-only;
+    }
 }
 
 .loadMore {

--- a/src/modules/InfiniteHubStories/InfiniteHubStories.tsx
+++ b/src/modules/InfiniteHubStories/InfiniteHubStories.tsx
@@ -100,12 +100,14 @@ export function InfiniteHubStories({
                     <NewsroomLogo key={newsroom.uuid} newsroom={newsroom} />
                 ))}
             </div>
-            {data.length > 0 && (
-                <PageTitle
-                    className={styles.title}
-                    title={formatMessage(translations.homepage.latestStories)}
-                />
-            )}
+            <PageTitle
+                className={classNames(styles.title, {
+                    // In case there's no included stories, we still need to render the heading
+                    // for accessibility purposes, but hide it to regular users
+                    [styles.aria]: data.length === 0,
+                })}
+                title={formatMessage(translations.homepage.latestStories)}
+            />
             <StoriesList
                 fullWidthFeaturedStory={false}
                 isCategoryList

--- a/src/modules/InfiniteStories/StoriesList.tsx
+++ b/src/modules/InfiniteStories/StoriesList.tsx
@@ -110,14 +110,12 @@ export function StoriesList({
                     })}
                 </div>
             )}
-            {hasCategories && (
-                <CategoriesFilters
-                    activeCategory={category}
-                    categories={categories}
-                    className={styles.filtersContainer}
-                    locale={locale}
-                />
-            )}
+            <CategoriesFilters
+                activeCategory={category}
+                categories={categories}
+                className={styles.filtersContainer}
+                locale={locale}
+            />
             {restStories.length > 0 && layout === 'grid' && (
                 <div
                     className={classNames(styles.storiesContainer, {

--- a/src/modules/InfiniteStories/ui/CategoriesFilters/CategoriesFilters.tsx
+++ b/src/modules/InfiniteStories/ui/CategoriesFilters/CategoriesFilters.tsx
@@ -24,16 +24,18 @@ export function CategoriesFilters({ activeCategory, categories, className, local
                 className={styles.title}
                 title={formatMessage(translations.homepage.latestStories)}
             />
-            <div className={styles.filters}>
-                <Filter isActive={activeCategory === undefined}>
-                    <FormattedMessage locale={locale} for={translations.homepage.allStories} />
-                </Filter>
-                {categories.map(({ id, display_name, i18n }) => (
-                    <Filter categoryId={id} isActive={activeCategory?.id === id} key={id}>
-                        {i18n[locale]?.name || display_name}
+            {categories.length > 0 && (
+                <div className={styles.filters}>
+                    <Filter isActive={activeCategory === undefined}>
+                        <FormattedMessage locale={locale} for={translations.homepage.allStories} />
                     </Filter>
-                ))}
-            </div>
+                    {categories.map(({ id, display_name, i18n }) => (
+                        <Filter categoryId={id} isActive={activeCategory?.id === id} key={id}>
+                            {i18n[locale]?.name || display_name}
+                        </Filter>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
Currently, if there's no featured categories in a non-hub site, the "Latest stories" H1 is not rendered at all which is a problem for WCAG (accessibility) guidelines. So the title is now always rendered.

For hub sites, the title was only rendered when there were stories included as well. I've changed this so the title is always rendered and if there's no stories, it's hidden out of the viewport so it's only accessible for the screen readers.