### PR TITLE
[DEV-20761] Fix - Do not render page title twice for hub sites

### DIFF
--- a/src/modules/InfiniteHubStories/InfiniteHubStories.module.scss
+++ b/src/modules/InfiniteHubStories/InfiniteHubStories.module.scss
@@ -31,14 +31,6 @@
     }
 }
 
-.title {
-    margin-bottom: $spacing-7;
-
-    &.aria {
-        @include sr-only;
-    }
-}
-
 .loadMore {
     display: flex;
     margin: $spacing-8 auto 0;

--- a/src/modules/InfiniteHubStories/InfiniteHubStories.tsx
+++ b/src/modules/InfiniteHubStories/InfiniteHubStories.tsx
@@ -2,13 +2,12 @@
 
 import type { Newsroom } from '@prezly/sdk';
 import type { Locale } from '@prezly/theme-kit-nextjs';
-import { translations, useInfiniteLoading, useIntl } from '@prezly/theme-kit-nextjs';
+import { translations, useInfiniteLoading } from '@prezly/theme-kit-nextjs';
 import classNames from 'classnames';
 import { useCallback } from 'react';
 
 import { FormattedMessage, http, useLocale } from '@/adapters/client';
 import { Button } from '@/components/Button';
-import { PageTitle } from '@/components/PageTitle';
 import type { ThemeSettings } from '@/theme-settings';
 import type { ListStory } from '@/types';
 
@@ -53,7 +52,6 @@ export function InfiniteHubStories({
     total,
 }: Props) {
     const locale = useLocale();
-    const { formatMessage } = useIntl();
     const includedNewsrooms = newsrooms.filter(({ uuid }) => uuid !== newsroomUuid);
 
     const { load, loading, data, done } = useInfiniteLoading(
@@ -100,14 +98,6 @@ export function InfiniteHubStories({
                     <NewsroomLogo key={newsroom.uuid} newsroom={newsroom} />
                 ))}
             </div>
-            <PageTitle
-                className={classNames(styles.title, {
-                    // In case there's no included stories, we still need to render the heading
-                    // for accessibility purposes, but hide it to regular users
-                    [styles.aria]: data.length === 0,
-                })}
-                title={formatMessage(translations.homepage.latestStories)}
-            />
             <StoriesList
                 fullWidthFeaturedStory={false}
                 isCategoryList

--- a/src/modules/InfiniteStories/StoriesList.tsx
+++ b/src/modules/InfiniteStories/StoriesList.tsx
@@ -114,6 +114,7 @@ export function StoriesList({
                 activeCategory={category}
                 categories={categories}
                 className={styles.filtersContainer}
+                hasStories={stories.length > 0}
                 locale={locale}
             />
             {restStories.length > 0 && layout === 'grid' && (

--- a/src/modules/InfiniteStories/ui/CategoriesFilters/CategoriesFilters.module.scss
+++ b/src/modules/InfiniteStories/ui/CategoriesFilters/CategoriesFilters.module.scss
@@ -1,5 +1,9 @@
 .title {
     margin-bottom: $spacing-5;
+
+    &.aria {
+        @include sr-only;
+    }
 }
 
 .filters {

--- a/src/modules/InfiniteStories/ui/CategoriesFilters/CategoriesFilters.tsx
+++ b/src/modules/InfiniteStories/ui/CategoriesFilters/CategoriesFilters.tsx
@@ -12,16 +12,27 @@ interface Props {
     activeCategory: Pick<Category, 'id'> | undefined;
     categories: Category[];
     className?: string;
+    hasStories: boolean;
     locale: Locale.Code;
 }
 
-export function CategoriesFilters({ activeCategory, categories, className, locale }: Props) {
+export function CategoriesFilters({
+    activeCategory,
+    categories,
+    className,
+    hasStories,
+    locale,
+}: Props) {
     const { formatMessage } = useIntl();
 
     return (
         <div className={className}>
             <PageTitle
-                className={styles.title}
+                className={classNames(styles.title, {
+                    // Hide the title for regular visitors if there's no stories,
+                    // but keep it for screen readers
+                    [styles.aria]: !hasStories,
+                })}
                 title={formatMessage(translations.homepage.latestStories)}
             />
             {categories.length > 0 && (


### PR DESCRIPTION
The "Latest stories" page title is now only rendered as part of `StoriesList` component for both hub and non-hub sites. For hub sites, the title is hidden for regular users but stays visible for screen readers.