### PR TITLE
[DEV-20892] Fix - Stretch logos to 100% width

### DIFF
--- a/src/modules/InfiniteHubStories/NewsroomLogo.module.scss
+++ b/src/modules/InfiniteHubStories/NewsroomLogo.module.scss
@@ -23,7 +23,7 @@
 
     img {
         display: block;
-        width: auto;
+        width: 100%;
         max-width: 100%;
         height: auto;
         max-height: 100%;


### PR DESCRIPTION
Before:
![Screenshot 2025-06-30 at 13 56 44](https://github.com/user-attachments/assets/a9605402-a004-41ea-899e-8d45fb60a146)

After:
![Screenshot 2025-06-30 at 13 56 52](https://github.com/user-attachments/assets/75464e2a-2959-4321-ab80-835982a6bb0e)
