### PR TITLE
[DEV-20117] Fix - Remove display: flex from the layout's content class

### DIFF
--- a/app/[localeCode]/layout.module.scss
+++ b/app/[localeCode]/layout.module.scss
@@ -7,9 +7,6 @@
 .content {
     @include container;
 
-    display: flex;
-    flex-direction: column;
-    flex: 1;
     padding-top: $spacing-8;
     padding-bottom: $spacing-9;
 }


### PR DESCRIPTION
This was added way back (4 years ago) and doesn't seem to be doing anything now other than breaking stuff so I've removed it.