### PR TITLE
[DEV-21191] Fix - Do not render extra page title on category/tag pages

### DIFF
--- a/src/modules/InfiniteStories/InfiniteStories.tsx
+++ b/src/modules/InfiniteStories/InfiniteStories.tsx
@@ -31,6 +31,7 @@ type Props = {
     storyCardVariant: ThemeSettings['story_card_variant'];
     tag?: string;
     total: number;
+    withPageTitle?: boolean;
 };
 
 function fetchStories(props: {
@@ -69,6 +70,7 @@ export function InfiniteStories({
     storyCardVariant,
     tag,
     total,
+    withPageTitle,
 }: Props) {
     const locale = useLocale();
     const { load, loading, data, done } = useInfiniteLoading(
@@ -102,6 +104,7 @@ export function InfiniteStories({
                 showSubtitle={showSubtitle}
                 stories={data}
                 storyCardVariant={storyCardVariant}
+                withPageTitle={withPageTitle}
             />
 
             {!done && (

--- a/src/modules/InfiniteStories/StoriesList.tsx
+++ b/src/modules/InfiniteStories/StoriesList.tsx
@@ -35,6 +35,7 @@ type Props = {
     stories: ListStory[];
     storyCardVariant: ThemeSettings['story_card_variant'];
     withEmptyState?: boolean;
+    withPageTitle?: boolean;
 };
 
 export function StoriesList({
@@ -51,6 +52,7 @@ export function StoriesList({
     stories,
     storyCardVariant,
     withEmptyState = true,
+    withPageTitle,
 }: Props) {
     const locale = useLocale();
     const { formatMessage } = useIntl();
@@ -113,14 +115,16 @@ export function StoriesList({
                     })}
                 </div>
             )}
-            <PageTitle
-                className={classNames(styles.pageTitle, {
-                    // We want to hide the page title for regular users, but keep it
-                    // for the screen readers.
-                    [styles.aria]: isCategoryList ? !hasStories : !hasCategories,
-                })}
-                title={formatMessage(translations.homepage.latestStories)}
-            />
+            {withPageTitle && (
+                <PageTitle
+                    className={classNames(styles.pageTitle, {
+                        // We want to hide the page title for regular users, but keep it
+                        // for the screen readers.
+                        [styles.aria]: isCategoryList ? !hasStories : !hasCategories,
+                    })}
+                    title={formatMessage(translations.homepage.latestStories)}
+                />
+            )}
             {hasCategories && (
                 <CategoriesFilters
                     activeCategory={category}

--- a/src/modules/Stories/Stories.tsx
+++ b/src/modules/Stories/Stories.tsx
@@ -53,6 +53,7 @@ export async function Stories({
             showSubtitle={showSubtitle}
             storyCardVariant={storyCardVariant}
             total={pagination.matched_records_number}
+            withPageTitle
         />
     );
 }


### PR DESCRIPTION
Since category/tag pages already render their own title, we don't want to render the "Latest stories" in that case as that's reserved only for homepage.