### PR TITLE
Fix - Update API calls for stories

### DIFF
--- a/app/api/stories/route.ts
+++ b/app/api/stories/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: NextRequest) {
     const { stories, pagination } = await app().stories({
         offset,
         limit,
-        category: categoryId ? { id: categoryId } : undefined,
+        categories: categoryId ? [{ id: categoryId }] : undefined,
         locale: locale ? { code: locale } : undefined,
         tags: tag ? [tag] : undefined,
     });

--- a/src/modules/Category/Category.tsx
+++ b/src/modules/Category/Category.tsx
@@ -27,7 +27,7 @@ export async function Category({
 }: Props) {
     const { stories, pagination } = await app().stories({
         limit: pageSize,
-        category,
+        categories: [category],
         locale: { code: translatedCategory.locale },
     });
 

--- a/src/modules/Stories/Stories.tsx
+++ b/src/modules/Stories/Stories.tsx
@@ -91,7 +91,7 @@ async function getStories({
             : undefined;
 
         const { stories, pagination } = await app().stories({
-            category: categoryId ? { id: categoryId } : undefined,
+            categories: categoryId ? [{ id: categoryId }] : undefined,
             limit: pageSize - 1,
             locale: { code: localeCode },
             query,


### PR DESCRIPTION
I've changed the `category` parameter to `categories` in one of the newer theme kit versions but Bea wasn't updated since then, so I've missed this error.

Curious that we don't build Bea as part of the PR checks.. we should probably update the Linter check to also run Typescript.