### PR TITLE
[DEV-21347] Fix - Update content renderer & apply margin on container and not table

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@meilisearch/instant-meilisearch": "0.26.0",
     "@playwright/test": "^1.50.1",
     "@prezly/analytics-nextjs": "4.3.0",
-    "@prezly/content-renderer-react-js": "0.43.3",
+    "@prezly/content-renderer-react-js": "0.43.4",
     "@prezly/sdk": "23.17.0",
     "@prezly/story-content-format": "0.70.0",
     "@prezly/theme-kit-nextjs": "10.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: 4.3.0
         version: 4.3.0(react@19.0.0)
       '@prezly/content-renderer-react-js':
-        specifier: 0.43.3
-        version: 0.43.3(js-cookie@3.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 0.43.4
+        version: 0.43.4(js-cookie@3.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@prezly/sdk':
         specifier: 23.17.0
         version: 23.17.0
@@ -1561,8 +1561,8 @@ packages:
   '@prezly/content-format@0.70.1':
     resolution: {integrity: sha512-qnD+ghv7MYDNtJ5F5N/ZUU7os+dflmoXzGKq3cqmbQ1vX9tZXJ0Hr27RsDHe/mAeTkHqV/UtezGuD06o2/e3kA==}
 
-  '@prezly/content-renderer-react-js@0.43.3':
-    resolution: {integrity: sha512-6+9dlPXUfymESax0sh8a4Kje+RT5q3u58SIYy4uoD66AvNHMsS4e30DHzVs+0xK57L4Q2CQquXhgVtz6X9b9iA==}
+  '@prezly/content-renderer-react-js@0.43.4':
+    resolution: {integrity: sha512-mL5yFTHyovwTMXKs0XhBL53NhsFFrpFBTdZJlcztt4zGh5y87YFi+YYactmg2qwa0Xoy6hDF7zaQwNB3u7NPZg==}
     peerDependencies:
       react: '18'
       react-dom: '18'
@@ -6987,7 +6987,7 @@ snapshots:
       '@prezly/uploads': 0.2.1
       is-plain-object: 5.0.0
 
-  '@prezly/content-renderer-react-js@0.43.3(js-cookie@3.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@prezly/content-renderer-react-js@0.43.4(js-cookie@3.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@prezly/linear-partition': 1.0.3
       '@prezly/sdk': 23.17.0

--- a/src/components/ContentRenderer/ContentRenderer.module.scss
+++ b/src/components/ContentRenderer/ContentRenderer.module.scss
@@ -25,7 +25,7 @@ $avatar-size: 60px;
             margin-bottom: $spacing-6;
         }
 
-        .prezly-slate-table {
+        .prezly-slate-table-container {
             margin-bottom: $spacing-6;
         }
 


### PR DESCRIPTION
- bottom margin moved to the table container instead of the table itself
- slightly reduced table width when overflowing