### PR TITLE
[DEV-21762] Fix - Tweak hub site logo layout

### DIFF
--- a/src/modules/InfiniteHubStories/InfiniteHubStories.module.scss
+++ b/src/modules/InfiniteHubStories/InfiniteHubStories.module.scss
@@ -7,7 +7,16 @@
         margin-bottom: $spacing-10;
     }
 
+    &.one {
+        grid-template-columns: 1fr;
+        justify-content: center;
+    }
+
     @include tablet-up {
+        &.one {
+            grid-template-columns: 373.33px;
+        }
+
         &.four {
             grid-template-columns: repeat(4, 1fr);
         }
@@ -25,7 +34,7 @@
         grid-template-columns: repeat(4, 1fr);
 
         &.two {
-            grid-template-columns: repeat(2, 1fr);
+            grid-template-columns: repeat(2, 373.33px);
         }
 
         &.three {

--- a/src/modules/InfiniteHubStories/InfiniteHubStories.tsx
+++ b/src/modules/InfiniteHubStories/InfiniteHubStories.tsx
@@ -73,24 +73,28 @@ export function InfiniteHubStories({
     );
 
     function getColumnsClassName() {
-        if (includedNewsrooms.length % 2 === 0) {
-            return styles.four;
+        if (includedNewsrooms.length === 1) {
+            return styles.one;
         }
 
         if (includedNewsrooms.length === 2) {
             return styles.two;
         }
 
-        if (includedNewsrooms.length % 3 === 0) {
-            return styles.three;
+        if (includedNewsrooms.length > 9) {
+            return styles.six;
         }
 
         if (includedNewsrooms.length % 5 === 0) {
             return styles.five;
         }
 
-        if (includedNewsrooms.length > 8) {
-            return styles.six;
+        if (includedNewsrooms.length % 3 === 0) {
+            return styles.three;
+        }
+
+        if (includedNewsrooms.length % 2 === 0) {
+            return styles.four;
         }
 
         return undefined;


### PR DESCRIPTION
Switched around the conditions so now the layout is correct when there's 1, 2 or more than 9 logos. For everything in between it works the same.

I've also tweaked the layout for 1 and 2 columns so the logos are smaller and centered.