### PR TITLE
Fix - Provide pathname as dependency

### DIFF
--- a/src/modules/Analytics/Analytics.tsx
+++ b/src/modules/Analytics/Analytics.tsx
@@ -20,7 +20,6 @@ export function Analytics(props: Config) {
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: Pathname is required here to trigger this effect on navigation
     useEffect(() => {
-        console.log('analytics effect');
         debouncedPage();
     }, [pathname, debouncedPage]);
 


### PR DESCRIPTION
This effect got broken after migrating to Biome because without the `pathname` as a dependency, the effect did not trigger on navigation.

Unused `pathname` also made the Biome checks fail, preventing deployments.