### PR TITLE
Move @playwright/test to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
         "@hcaptcha/react-hcaptcha": "1.16.0",
         "@headlessui/react": "2.2.9",
         "@meilisearch/instant-meilisearch": "0.26.0",
-        "@playwright/test": "^1.50.1",
         "@prezly/analytics-nextjs": "4.3.0",
         "@prezly/content-renderer-react-js": "0.44.0",
         "@prezly/sdk": "23.17.0",
@@ -57,6 +56,7 @@
     },
     "devDependencies": {
         "@biomejs/biome": "2.2.4",
+        "@playwright/test": "^1.50.1",
         "@next/bundle-analyzer": "15.5.12",
         "@prezly/biome-config": "1.0.1",
         "@svgr/webpack": "8.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ importers:
       '@meilisearch/instant-meilisearch':
         specifier: 0.26.0
         version: 0.26.0
-      '@playwright/test':
-        specifier: ^1.50.1
-        version: 1.57.0
       '@prezly/analytics-nextjs':
         specifier: 4.3.0
         version: 4.3.0(react@19.2.4)
@@ -109,6 +106,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: 15.5.12
         version: 15.5.12
+      '@playwright/test':
+        specifier: ^1.50.1
+        version: 1.57.0
       '@prezly/biome-config':
         specifier: 1.0.1
         version: 1.0.1(@biomejs/biome@2.2.4)


### PR DESCRIPTION
## Summary
This PR moves `@playwright/test` out of runtime dependencies because it is only used for end-to-end tests and Playwright configuration. Keeping it in `devDependencies` avoids shipping test tooling in production installs.

## Changes
- Remove `@playwright/test` from `dependencies` in `package.json`
- Add `@playwright/test` to `devDependencies` in `package.json`
- Update `pnpm-lock.yaml` importer sections to match the dependency move

## Testing
Not run (dependency metadata and lockfile-only change).