### PR TITLE
chore: remove unused next-logger and server-only deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "react-instantsearch-dom": "6.40.4",
-        "server-only": "0.0.1",
         "social-links": "1.15.1",
         "tinycolor2": "1.6.0",
         "url-pattern": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
         "@types/tinycolor2": "1.4.6",
         "autoprefixer": "10.4.21",
         "dotenv": "^16.4.7",
-        "next-logger": "5.0.1",
         "np": "10.2.0",
         "postcss": "8.5.3",
         "sass": "1.85.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,9 +142,6 @@ importers:
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
-      next-logger:
-        specifier: 5.0.1
-        version: 5.0.1(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(pino@9.6.0)
       np:
         specifier: 10.2.0
         version: 10.2.0(@types/node@22.13.5)(typescript@5.8.3)
@@ -3225,10 +3222,6 @@ packages:
   leac@0.6.0:
     resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
-  lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
-
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -3427,18 +3420,6 @@ packages:
   new-github-release-url@2.0.0:
     resolution: {integrity: sha512-NHDDGYudnvRutt/VhKFlX26IotXe1w0cmkDm6JGquh5bz/bDTw0LufSmH/GxTjEdpHEO+bVKFTwdrcGa/9XlKQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  next-logger@5.0.1:
-    resolution: {integrity: sha512-zWTPtS0YwTB+4iSK4VxUVtCYt+zg8+Sx2Tjbtgmpd4SXsFnWdmCbXAeFZFKtEH8yNlucLCUaj0xqposMQ9rKRg==}
-    peerDependencies:
-      next: '>=9.0.0'
-      pino: ^8.0.0 || ^9.0.0
-      winston: ^3.0.0
-    peerDependenciesMeta:
-      pino:
-        optional: true
-      winston:
-        optional: true
 
   next@15.5.12:
     resolution: {integrity: sha512-Fi/wQ4Etlrn60rz78bebG1i1SR20QxvV8tVp6iJspjLUSHcZoeUXCt+vmWoEcza85ElZzExK/jJ/F6SvtGktjA==}
@@ -7766,8 +7747,6 @@ snapshots:
 
   leac@0.6.0: {}
 
-  lilconfig@3.1.3: {}
-
   lines-and-columns@1.2.4: {}
 
   listr-input@0.2.1:
@@ -7946,13 +7925,6 @@ snapshots:
   new-github-release-url@2.0.0:
     dependencies:
       type-fest: 2.19.0
-
-  next-logger@5.0.1(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(pino@9.6.0):
-    dependencies:
-      lilconfig: 3.1.3
-      next: 15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1)
-    optionalDependencies:
-      pino: 9.6.0
 
   next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,6 @@ importers:
       react-instantsearch-dom:
         specifier: 6.40.4
         version: 6.40.4(algoliasearch@5.46.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      server-only:
-        specifier: 0.0.1
-        version: 0.0.1
       social-links:
         specifier: 1.15.1
         version: 1.15.1
@@ -3981,9 +3978,6 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
-
-  server-only@0.0.1:
-    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -8550,8 +8544,6 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
-
-  server-only@0.0.1: {}
 
   set-function-length@1.2.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Remove `server-only` from runtime dependencies and lockfile because it has no imports.
- Remove `next-logger` from dev dependencies and lockfile because it has no code/config usage.
- Keep dependency manifest aligned with actual usage to reduce maintenance overhead.

## Testing
- Not run (dependency manifest + lockfile cleanup only).