### PR TITLE
[DEV-22627] Fix redirects checks for non-ascii url-encoded slugs

### DIFF
--- a/app/[localeCode]/(story)/[slug]/page.tsx
+++ b/app/[localeCode]/(story)/[slug]/page.tsx
@@ -21,8 +21,10 @@ async function resolve(params: Props['params']) {
     const story = await app().story({ slug });
     if (!story) notFound();
 
-    if (story.slug !== slug) {
-        return redirect(configureAppRouter().generate('story', { slug: story.slug }));
+    if (story.slug !== slug && encodeURIComponent(story.slug) !== slug) {
+        return redirect(
+            configureAppRouter().generate('story', { slug: encodeURIComponent(story.slug) }),
+        );
     }
 
     const { stories: relatedStories } = await app().stories({

--- a/app/[localeCode]/(story)/[slug]/page.tsx
+++ b/app/[localeCode]/(story)/[slug]/page.tsx
@@ -22,9 +22,7 @@ async function resolve(params: Props['params']) {
     if (!story) notFound();
 
     if (story.slug !== slug && encodeURIComponent(story.slug) !== slug) {
-        return redirect(
-            configureAppRouter().generate('story', { slug: encodeURIComponent(story.slug) }),
-        );
+        return redirect(configureAppRouter().generate('story', { slug: story.slug }));
     }
 
     const { stories: relatedStories } = await app().stories({

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@prezly/content-renderer-react-js": "0.44.0",
         "@prezly/sdk": "23.17.0",
         "@prezly/story-content-format": "0.70.0",
-        "@prezly/theme-kit-nextjs": "10.6.1",
+        "@prezly/theme-kit-nextjs": "10.6.2",
         "@prezly/uploadcare": "2.6.0",
         "@prezly/uploadcare-image": "0.3.2",
         "@react-hookz/web": "14.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 0.70.0
         version: 0.70.0
       '@prezly/theme-kit-nextjs':
-        specifier: 10.6.1
-        version: 10.6.1(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 10.6.2
+        version: 10.6.2(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@prezly/uploadcare':
         specifier: 2.6.0
         version: 2.6.0
@@ -1572,18 +1572,18 @@ packages:
   '@prezly/story-content-format@0.70.1':
     resolution: {integrity: sha512-q5nwvlz161PsSB0nTBUBzXPHIgV+8euCCPHGB6NUUNpIpkM2JD9lp8zJnETs2REcOhsTaPMw/oum9Mbp2Qvk4A==}
 
-  '@prezly/theme-kit-core@10.6.1':
-    resolution: {integrity: sha512-OURN4J6T9iIlEgtz/S5gYd/fGtSgsYS85s20LuwiT3DWPBxDIOU3neJaE2kxePqHyL0k0LI8T/56F6F+9ySOPg==}
+  '@prezly/theme-kit-core@10.6.2':
+    resolution: {integrity: sha512-wNIvY2m0cVUt8tTdaJ/daEBf4myZSa6VQkTnObBIrin4CLc+0rbFY6YlNQUcCyYl3tWCHmGe9sZMhqpDMZq3Ag==}
     engines: {node: '>= 16.x', npm: '>= 8.x'}
     peerDependencies:
       '@prezly/sdk': 21.12.0 || ^23.x
 
-  '@prezly/theme-kit-intl@10.6.1':
-    resolution: {integrity: sha512-uy6oXWi3mVcwzQQn1puCkj7lDj6Dv0xQIbAKbWf34L/Tgh4qui2Q+YSOlMxCSCGfsfpO7XRsfUg9DEoP6Penhw==}
+  '@prezly/theme-kit-intl@10.6.2':
+    resolution: {integrity: sha512-/rkif1Tq92EtLF2IcIV1PhitwIWpH3uk9dabGhYHZUorPWFbwCKoQqpZV0xk0gXh7UO0uQuzcpQRBWaeJTQFVA==}
     engines: {node: '>= 14.x', npm: '>= 7.x'}
 
-  '@prezly/theme-kit-nextjs@10.6.1':
-    resolution: {integrity: sha512-RuUHBux2rFDgzMlj7nEl5evDWcgYZRWUMj5MVQJPvPJH5F0BFzYsfpqpv4auvz+X3djRRvw6Q42UxexoPWGWMA==}
+  '@prezly/theme-kit-nextjs@10.6.2':
+    resolution: {integrity: sha512-6T2s29d4cvZdp5RFOOBpkZzpvxfdFcaCxsHSMBCAGuOfttLftpJdZbGqu4DhMsCi1aSVPj4LJ+J02Ao4Ypns9w==}
     engines: {node: '>= 16.x', npm: '>= 8.x'}
     peerDependencies:
       '@playwright/test': 1.x
@@ -1595,8 +1595,8 @@ packages:
       '@playwright/test':
         optional: true
 
-  '@prezly/theme-kit-react@10.6.1':
-    resolution: {integrity: sha512-D1L8JQnGfJnJdhSEXxSZtKwtbNQf4MTLUy10hjqB4LmuM7XH78t9HoCUMOcLLdnx7sJQUY7m6GpiAgTa7FToqw==}
+  '@prezly/theme-kit-react@10.6.2':
+    resolution: {integrity: sha512-lWWgGlUPHcVkUcFsgbM2S8AsCfF6rgrIgoTtC9DLxI3OzlTSJrz4QrMlRTurckhyK6AG6K6l0HP+wLJNH/YfOg==}
     engines: {node: '>= 20.x', npm: '>= 8.x'}
     peerDependencies:
       react: ^18.x || ^19.x
@@ -6050,26 +6050,26 @@ snapshots:
       '@prezly/uploads': 0.2.1
       is-plain-object: 5.0.0
 
-  '@prezly/theme-kit-core@10.6.1(@prezly/sdk@23.17.0)':
+  '@prezly/theme-kit-core@10.6.2(@prezly/sdk@23.17.0)':
     dependencies:
       '@prezly/sdk': 23.17.0
-      '@prezly/theme-kit-intl': 10.6.1
+      '@prezly/theme-kit-intl': 10.6.2
       '@prezly/uploadcare': 2.4.4
       '@technically/is-not-undefined': 1.0.0
       '@technically/omit-undefined': 1.0.4
       parse-data-url: 6.0.0
       url-pattern: 1.0.3
 
-  '@prezly/theme-kit-intl@10.6.1':
+  '@prezly/theme-kit-intl@10.6.2':
     dependencies:
       '@technically/is-not-undefined': 1.0.0
 
-  '@prezly/theme-kit-nextjs@10.6.1(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@prezly/theme-kit-nextjs@10.6.2(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@prezly/sdk': 23.17.0
-      '@prezly/theme-kit-core': 10.6.1(@prezly/sdk@23.17.0)
-      '@prezly/theme-kit-intl': 10.6.1
-      '@prezly/theme-kit-react': 10.6.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@prezly/theme-kit-core': 10.6.2(@prezly/sdk@23.17.0)
+      '@prezly/theme-kit-intl': 10.6.2
+      '@prezly/theme-kit-react': 10.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@technically/is-not-undefined': 1.0.0
       '@technically/omit-undefined': 1.0.4
       json-stable-stringify: 1.3.0
@@ -6081,9 +6081,9 @@ snapshots:
     optionalDependencies:
       '@playwright/test': 1.57.0
 
-  '@prezly/theme-kit-react@10.6.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@prezly/theme-kit-react@10.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@prezly/theme-kit-intl': 10.6.1
+      '@prezly/theme-kit-intl': 10.6.2
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 


### PR DESCRIPTION
This fixes two problems:

1. The condition was comparing URL param `slug` (which can be URL encoded) with `story.slug` which is never URL encoded
2. The `redirect()` function was not happy about having non-ascii unicode characters in the URL

   > TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["Location"]
 
   I've fixed this upstream in the Theme-Kit package: https://github.com/prezly/theme-kit-js/pull/1020
 