### PR TITLE
[DEV-22697] Fix - Align story heading levels between rendered page and JSON output

### DIFF
--- a/src/components/RichText/Heading.tsx
+++ b/src/components/RichText/Heading.tsx
@@ -20,8 +20,8 @@ export function Heading({ node, children }: Props) {
     });
 
     if (node.type === HeadingNode.Type.HEADING_ONE) {
-        return <h2 className={className}>{children}</h2>;
+        return <h3 className={className}>{children}</h3>;
     }
 
-    return <h3 className={className}>{children}</h3>;
+    return <h4 className={className}>{children}</h4>;
 }


### PR DESCRIPTION
Fixes a heading-level mismatch between story pages and story `.json` output.

Previously, headings were shifted by one level in JSON (`h2 -> h3`, `h3 -> h4`) compared to the rendered story. This change aligns heading serialization so both outputs use consistent heading tags.