### PR TITLE
[DEV-22111] Add reverse-proxy subpath support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,16 @@ MEILISEARCH_API_KEY=
 # Uploadcare variables
 NEXT_PUBLIC_UPLOADCARE_PUBLIC_KEY=97775dfb0ac5a6446bce
 NEXT_PUBLIC_UPLOADCARE_CUSTOM_CDN_DOMAIN=cdn.uc.assets.prezly.com
+
+# Reverse-proxy / subdirectory path support. Both are optional; leave unset for standard Bea.
+# In multi-tenant deployments these come via the X-Prezly-Env header per request.
+#
+# THEME_BASE_PATH: flat prefix applied at the root (all URLs served under this prefix).
+# Example for https://customer.com/presscentre/*:
+# THEME_BASE_PATH=/presscentre
+#
+# THEME_LOCALE_SUBDIR: subdirectory inserted after the locale slug. Supports a "*"
+# wildcard (applies to any locale) or explicit per-locale mapping.
+# Example for https://customer.com/<locale>/news/*:
+# THEME_LOCALE_SUBDIR=*:news
+# THEME_LOCALE_SUBDIR=nl_BE:news,fr_BE:news

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,9 @@
 import { Locale } from '@prezly/theme-kit-nextjs';
 import { IntlMiddleware } from '@prezly/theme-kit-nextjs/middleware';
-import type { NextRequest } from 'next/server';
+import { NextRequest, type NextResponse } from 'next/server';
 
 import { configureAppRouter, initPrezlyClient } from '@/adapters/server';
+import { applyBasePath, parseBasePathConfig, stripBasePath } from '@/utils';
 
 function parseNewsroomLocalesFromHeaders(headers: Headers): Locale.Code[] | undefined {
     const header = headers.get('X-Newsroom-Locales');
@@ -38,18 +39,105 @@ async function retrieveNewsroomLocalesFromApi(headers: Headers) {
     return prioritizedLanguages.map((lang) => lang.code);
 }
 
+function readThemePathEnv(header: string | null): {
+    THEME_BASE_PATH?: string;
+    THEME_LOCALE_SUBDIR?: string;
+} {
+    const fromHeader = decodeThemeEnvHeader(header);
+    return {
+        THEME_BASE_PATH: fromHeader.THEME_BASE_PATH ?? process.env.THEME_BASE_PATH,
+        THEME_LOCALE_SUBDIR: fromHeader.THEME_LOCALE_SUBDIR ?? process.env.THEME_LOCALE_SUBDIR,
+    };
+}
+
+function decodeThemeEnvHeader(header: string | null): {
+    THEME_BASE_PATH?: string;
+    THEME_LOCALE_SUBDIR?: string;
+} {
+    if (!header) return {};
+    let json = header;
+    if (header.startsWith('data:')) {
+        const commaIdx = header.indexOf(',');
+        if (commaIdx === -1) return {};
+        const meta = header.slice(5, commaIdx);
+        const payload = header.slice(commaIdx + 1);
+        if (!meta.includes('application/json')) return {};
+        try {
+            json = meta.includes('base64') ? atob(payload) : decodeURIComponent(payload);
+        } catch {
+            return {};
+        }
+    }
+    try {
+        const parsed = JSON.parse(json) as Record<string, unknown>;
+        if (parsed && typeof parsed === 'object') {
+            return {
+                THEME_BASE_PATH:
+                    typeof parsed.THEME_BASE_PATH === 'string' ? parsed.THEME_BASE_PATH : undefined,
+                THEME_LOCALE_SUBDIR:
+                    typeof parsed.THEME_LOCALE_SUBDIR === 'string'
+                        ? parsed.THEME_LOCALE_SUBDIR
+                        : undefined,
+            };
+        }
+    } catch {
+        // pass-through
+    }
+    return {};
+}
+
 export async function middleware(request: NextRequest) {
+    const config = parseBasePathConfig(readThemePathEnv(request.headers.get('X-Prezly-Env')));
+
+    const originalPathname = request.nextUrl.pathname;
+    const strippedPathname = stripBasePath(originalPathname, config);
+
+    let effectiveRequest = request;
+    if (strippedPathname !== originalPathname) {
+        const nextUrl = request.nextUrl.clone();
+        nextUrl.pathname = strippedPathname;
+        effectiveRequest = new NextRequest(nextUrl, request);
+    }
+
     const locales =
         parseNewsroomLocalesFromHeaders(request.headers) ??
         (await retrieveNewsroomLocalesFromApi(request.headers));
 
     const [defaultLocale] = locales; // default is expected to always be the first in the list
 
-    return IntlMiddleware.handle(request, {
+    const response = await IntlMiddleware.handle(effectiveRequest, {
         router: configureAppRouter(),
         locales,
         defaultLocale,
     });
+
+    if (strippedPathname !== originalPathname) {
+        return reapplyBasePathToRedirect(response, config, effectiveRequest);
+    }
+
+    return response;
+}
+
+function reapplyBasePathToRedirect(
+    response: NextResponse,
+    config: ReturnType<typeof parseBasePathConfig>,
+    request: NextRequest,
+): NextResponse {
+    const location = response.headers.get('location');
+    if (!location) return response;
+
+    try {
+        const locUrl = new URL(location, request.nextUrl);
+        if (locUrl.origin !== request.nextUrl.origin) return response;
+
+        const [maybeLocale] = locUrl.pathname.split('/').filter(Boolean);
+        locUrl.pathname = applyBasePath(locUrl.pathname, config, maybeLocale);
+        response.headers.set('location', locUrl.toString());
+    } catch {
+        // malformed Location header — leave unchanged
+    }
+
+    return response;
 }
 
 export const config = {

--- a/src/adapters/client/routing.ts
+++ b/src/adapters/client/routing.ts
@@ -1,9 +1,0 @@
-'use client';
-
-import { RoutingAdapter } from '@prezly/theme-kit-nextjs';
-
-import type { AppRoutes } from '../server/routing';
-
-export type * from '../server/routing';
-
-export const { useRouting, RoutingContextProvider } = RoutingAdapter.connect<AppRoutes>();

--- a/src/adapters/client/routing.tsx
+++ b/src/adapters/client/routing.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { RoutingAdapter } from '@prezly/theme-kit-nextjs';
+import { createContext, type ReactNode, useContext } from 'react';
+
+import { applyBasePath, type BasePathConfig } from '@/utils';
+
+import { useLocale } from './locale';
+
+import type { AppRoutes } from '../server/routing';
+
+export type * from '../server/routing';
+
+const { useRouting: baseUseRouting, RoutingContextProvider } = RoutingAdapter.connect<AppRoutes>();
+
+const BasePathContext = createContext<BasePathConfig>({});
+
+export { RoutingContextProvider };
+
+export function BasePathProvider({
+    config,
+    children,
+}: {
+    config: BasePathConfig;
+    children: ReactNode;
+}) {
+    return <BasePathContext.Provider value={config}>{children}</BasePathContext.Provider>;
+}
+
+export function useRouting() {
+    const base = baseUseRouting();
+    const config = useContext(BasePathContext);
+    const currentLocale = useLocale();
+
+    const generateUrl: typeof base.generateUrl = ((routeName: string, ...rest: unknown[]) => {
+        const url = (base.generateUrl as (name: string, ...args: unknown[]) => `/${string}`)(
+            routeName,
+            ...rest,
+        );
+        const params = rest[0] as { localeCode?: string } | undefined;
+        return applyBasePath(url, config, params?.localeCode ?? currentLocale) as `/${string}`;
+    }) as typeof base.generateUrl;
+
+    return { generateUrl };
+}

--- a/src/adapters/server/environment.ts
+++ b/src/adapters/server/environment.ts
@@ -17,6 +17,9 @@ const Schema = z.object({
     MEILISEARCH_INDEX: z.string().optional(),
 
     PREZLY_MODE: z.string().optional(),
+
+    THEME_BASE_PATH: z.string().optional(),
+    THEME_LOCALE_SUBDIR: z.string().optional(),
 });
 
 export type Environment = z.infer<typeof Schema>;

--- a/src/adapters/server/routing.ts
+++ b/src/adapters/server/routing.ts
@@ -1,14 +1,17 @@
 import type { UrlGenerator } from '@prezly/theme-kit-nextjs';
 import { Route, Router, RoutingAdapter } from '@prezly/theme-kit-nextjs/server';
 
+import { applyBasePath, applyBasePathAbsolute, parseBasePathConfig } from '@/utils';
+
 import { app } from './app';
+import { environment } from './environment';
 
 export type AppRouter = ReturnType<typeof configureAppRouter>;
 export type AppRoutes = AppRouter['routes'];
 export type AppUrlGenerator = UrlGenerator<AppRouter>;
 export type AppUrlGeneratorParams = UrlGenerator.Params<AppRouter>;
 
-export const { useRouting: routing } = RoutingAdapter.connect(configureAppRouter, async () => {
+const { useRouting: baseRouting } = RoutingAdapter.connect(configureAppRouter, async () => {
     const [newsroom, locales, defaultLocale] = await Promise.all([
         app().newsroom(),
         app().locales(),
@@ -20,6 +23,43 @@ export const { useRouting: routing } = RoutingAdapter.connect(configureAppRouter
         origin: new URL(newsroom.url).origin as `http://${string}` | `https://${string}`,
     };
 });
+
+export async function routing() {
+    const base = await baseRouting();
+    const config = parseBasePathConfig(environment());
+
+    const generateUrl: typeof base.generateUrl = ((routeName: string, ...rest: unknown[]) => {
+        const url = (base.generateUrl as (name: string, ...args: unknown[]) => `/${string}`)(
+            routeName,
+            ...rest,
+        );
+        const params = rest[0] as { localeCode?: string } | undefined;
+        return applyBasePath(url, config, params?.localeCode) as `/${string}`;
+    }) as typeof base.generateUrl;
+
+    const generateAbsoluteUrl: typeof base.generateAbsoluteUrl = ((
+        routeName: string,
+        ...rest: unknown[]
+    ) => {
+        const url = (
+            base.generateAbsoluteUrl as (
+                name: string,
+                ...args: unknown[]
+            ) => `http://${string}` | `https://${string}`
+        )(routeName, ...rest);
+        const params = rest[0] as { localeCode?: string } | undefined;
+        return applyBasePathAbsolute(url, config, params?.localeCode) as
+            | `http://${string}`
+            | `https://${string}`;
+    }) as typeof base.generateAbsoluteUrl;
+
+    return {
+        ...base,
+        basePathConfig: config,
+        generateUrl,
+        generateAbsoluteUrl,
+    };
+}
 
 export function configureAppRouter() {
     const route = Route.create;

--- a/src/modules/Routing/RoutingProvider.tsx
+++ b/src/modules/Routing/RoutingProvider.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react';
 
-import { RoutingContextProvider } from '@/adapters/client';
+import { BasePathProvider, RoutingContextProvider } from '@/adapters/client';
 import { app, routing } from '@/adapters/server';
 
 interface Props {
@@ -8,17 +8,19 @@ interface Props {
 }
 
 export async function RoutingProvider({ children }: Props) {
-    const { router } = await routing();
+    const { router, basePathConfig } = await routing();
     const locales = await app().locales();
     const defaultLocale = await app().defaultLocale();
 
     return (
-        <RoutingContextProvider
-            routes={router.dump()}
-            locales={locales}
-            defaultLocale={defaultLocale}
-        >
-            {children}
-        </RoutingContextProvider>
+        <BasePathProvider config={basePathConfig}>
+            <RoutingContextProvider
+                routes={router.dump()}
+                locales={locales}
+                defaultLocale={defaultLocale}
+            >
+                {children}
+            </RoutingContextProvider>
+        </BasePathProvider>
     );
 }

--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -56,12 +56,15 @@ export function stripBasePath(pathname: string, config: BasePathConfig): string 
 
     if (localeSubdir) {
         const segments = result.split('/').filter(Boolean);
-        const subdirs = new Set(Object.values(localeSubdir));
 
-        if (segments.length >= 2 && LOCALE_SHAPE.test(segments[0]) && subdirs.has(segments[1])) {
+        if (
+            segments.length >= 2 &&
+            LOCALE_SHAPE.test(segments[0]) &&
+            isConfiguredSubdir(segments[0], segments[1], localeSubdir)
+        ) {
             segments.splice(1, 1);
             result = `/${segments.join('/')}`;
-        } else if (segments.length >= 1 && localeSubdir['*'] && subdirs.has(segments[0])) {
+        } else if (segments.length >= 1 && segments[0] === localeSubdir['*']) {
             segments.shift();
             result = segments.length > 0 ? `/${segments.join('/')}` : '/';
         }
@@ -136,5 +139,18 @@ function slugMatchesLocale(slug: string, localeCode: string): boolean {
     if (slug.toLowerCase() === localeCode.toLowerCase()) return true;
     if (slug.toLowerCase() === localeCode.replace(/_/g, '-').toLowerCase()) return true;
     if (slug === localeCode.split(/[-_]/)[0]) return true;
+    if (localeCode === slug.split(/[-_]/)[0]) return true;
+    return false;
+}
+
+function isConfiguredSubdir(
+    slug: string,
+    candidate: string,
+    localeSubdir: Record<string, string>,
+): boolean {
+    for (const [key, value] of Object.entries(localeSubdir)) {
+        if (value !== candidate) continue;
+        if (key === '*' || slugMatchesLocale(slug, key)) return true;
+    }
     return false;
 }

--- a/src/utils/basePath.ts
+++ b/src/utils/basePath.ts
@@ -1,0 +1,140 @@
+export interface BasePathConfig {
+    basePath?: string;
+    localeSubdir?: Record<string, string>;
+}
+
+const LOCALE_SHAPE = /^[a-z]{2,3}([_-][A-Za-z0-9]{2,4})?$/;
+
+export function parseBasePathConfig(env: {
+    THEME_BASE_PATH?: string;
+    THEME_LOCALE_SUBDIR?: string;
+}): BasePathConfig {
+    return {
+        basePath: normalizeBasePath(env.THEME_BASE_PATH),
+        localeSubdir: parseLocaleSubdirMap(env.THEME_LOCALE_SUBDIR),
+    };
+}
+
+export function applyBasePath(url: string, config: BasePathConfig, localeCode?: string): string {
+    if (!url.startsWith('/')) return url;
+
+    const { basePath } = config;
+    const subdir = subdirForLocale(config, localeCode);
+
+    let canonical = url;
+    if (basePath && (canonical === basePath || canonical.startsWith(`${basePath}/`))) {
+        canonical = canonical.slice(basePath.length) || '/';
+    }
+
+    const rebuilt = insertLocaleSubdir(canonical, subdir, localeCode);
+    return basePath ? prependBasePath(basePath, rebuilt) : rebuilt;
+}
+
+export function applyBasePathAbsolute(
+    url: string,
+    config: BasePathConfig,
+    localeCode?: string,
+): string {
+    try {
+        const parsed = new URL(url);
+        parsed.pathname = applyBasePath(parsed.pathname || '/', config, localeCode);
+        return parsed.toString();
+    } catch {
+        return url;
+    }
+}
+
+export function stripBasePath(pathname: string, config: BasePathConfig): string {
+    if (!pathname.startsWith('/')) return pathname;
+
+    let result = pathname;
+
+    const { basePath, localeSubdir } = config;
+    if (basePath && (result === basePath || result.startsWith(`${basePath}/`))) {
+        result = result.slice(basePath.length) || '/';
+    }
+
+    if (localeSubdir) {
+        const segments = result.split('/').filter(Boolean);
+        const subdirs = new Set(Object.values(localeSubdir));
+
+        if (segments.length >= 2 && LOCALE_SHAPE.test(segments[0]) && subdirs.has(segments[1])) {
+            segments.splice(1, 1);
+            result = `/${segments.join('/')}`;
+        } else if (segments.length >= 1 && localeSubdir['*'] && subdirs.has(segments[0])) {
+            segments.shift();
+            result = segments.length > 0 ? `/${segments.join('/')}` : '/';
+        }
+    }
+
+    return result;
+}
+
+function normalizeBasePath(raw: string | undefined): string | undefined {
+    if (!raw) return undefined;
+    const trimmed = raw.trim().replace(/\/+$/, '');
+    if (!trimmed || trimmed === '/') return undefined;
+    return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+function parseLocaleSubdirMap(raw: string | undefined): Record<string, string> | undefined {
+    if (!raw) return undefined;
+    const map: Record<string, string> = {};
+    for (const entry of raw.split(',')) {
+        const [key, value] = entry.split(':').map((s) => s.trim());
+        if (!key || !value) continue;
+        map[key] = value.replace(/^\/+|\/+$/g, '');
+    }
+    return Object.keys(map).length > 0 ? map : undefined;
+}
+
+function subdirForLocale(
+    config: BasePathConfig,
+    localeCode: string | undefined,
+): string | undefined {
+    const map = config.localeSubdir;
+    if (!map) return undefined;
+    if (localeCode) {
+        if (map[localeCode]) return map[localeCode];
+        const short = localeCode.split(/[-_]/)[0];
+        if (map[short]) return map[short];
+    }
+    return map['*'];
+}
+
+function prependBasePath(basePath: string, rest: string): string {
+    if (rest === '/') return basePath;
+    return `${basePath}${rest}`;
+}
+
+function insertLocaleSubdir(
+    canonical: string,
+    subdir: string | undefined,
+    localeCode: string | undefined,
+): string {
+    if (!subdir) return canonical;
+
+    const segments = canonical.split('/').filter(Boolean);
+    if (segments.length === 0) {
+        return `/${subdir}`;
+    }
+
+    const firstIsLocale = localeCode ? slugMatchesLocale(segments[0], localeCode) : false;
+
+    if (firstIsLocale) {
+        if (segments[1] === subdir) return canonical;
+        return `/${[segments[0], subdir, ...segments.slice(1)].join('/')}`;
+    }
+
+    if (segments[0] === subdir) return canonical;
+    return `/${[subdir, ...segments].join('/')}`;
+}
+
+function slugMatchesLocale(slug: string, localeCode: string): boolean {
+    if (slug === localeCode) return true;
+    if (slug === localeCode.replace(/_/g, '-')) return true;
+    if (slug.toLowerCase() === localeCode.toLowerCase()) return true;
+    if (slug.toLowerCase() === localeCode.replace(/_/g, '-').toLowerCase()) return true;
+    if (slug === localeCode.split(/[-_]/)[0]) return true;
+    return false;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,11 @@
 export { analytics } from './analytics';
+export {
+    applyBasePath,
+    applyBasePathAbsolute,
+    type BasePathConfig,
+    parseBasePathConfig,
+    stripBasePath,
+} from './basePath';
 export { clamp } from './clamp';
 export { ensureTrailingSlash } from './ensureTrailingSlash';
 export { getNewsroomPlaceholderColors } from './getNewsroomPlaceholderColors';


### PR DESCRIPTION
Adds opt-in per-request base path handling for newsrooms served behind a reverse proxy at a subdirectory. Config comes via the existing X-Prezly-Env pipeline as two optional variables:

- THEME_BASE_PATH: flat prefix at root (e.g. /presscentre)
- THEME_LOCALE_SUBDIR: subdir after the locale slug, per-locale or '*' wildcard (e.g. *:news for /<locale>/news/*)

Server routing() and client useRouting() wrap generateUrl so every emitted URL (pages, metadata, sitemap, Link, search, broadcast) picks up the prefix automatically. Middleware parses X-Prezly-Env inline (Edge-safe, no next/headers) and strips the prefix before IntlMiddleware runs, then re-applies it to any redirect Location header so the browser stays on the user-visible URL. BasePathConfig is serialized through a BasePathProvider so the client wrap sees the same value.

Unset vars are a no-op; standard Bea is unchanged.