### PR TITLE
[DEV-22375] Implement anchor links in themes

### DIFF
--- a/src/components/RichText/Heading.tsx
+++ b/src/components/RichText/Heading.tsx
@@ -27,7 +27,7 @@ export function Heading({ node, children }: Props) {
         [styles.alignJustify]: node.align === TextAlignment.JUSTIFY,
     });
 
-    const id = slugifyHeading(extractText(node.children));
+    const id = `header-${slugifyHeading(extractText(node.children))}`;
 
     if (node.type === HeadingNode.Type.HEADING_ONE) {
         return (

--- a/src/components/RichText/Heading.tsx
+++ b/src/components/RichText/Heading.tsx
@@ -2,11 +2,20 @@ import { HeadingNode, TextAlignment } from '@prezly/story-content-format';
 import classNames from 'classnames';
 import type { ReactNode } from 'react';
 
+import { slugifyHeading } from '@/utils';
+
 import styles from './styles.module.scss';
 
 interface Props {
     node: HeadingNode;
     children?: ReactNode;
+}
+
+function extractText(children: HeadingNode['children']): string {
+    return children
+        .map((child) => ('text' in child ? child.text : extractText((child as any).children ?? []))
+        )
+        .join('');
 }
 
 export function Heading({ node, children }: Props) {
@@ -19,9 +28,11 @@ export function Heading({ node, children }: Props) {
         [styles.alignJustify]: node.align === TextAlignment.JUSTIFY,
     });
 
+    const id = slugifyHeading(extractText(node.children));
+
     if (node.type === HeadingNode.Type.HEADING_ONE) {
-        return <h3 className={className}>{children}</h3>;
+        return <h3 id={id} className={className}>{children}</h3>;
     }
 
-    return <h4 className={className}>{children}</h4>;
+    return <h4 id={id} className={className}>{children}</h4>;
 }

--- a/src/components/RichText/Heading.tsx
+++ b/src/components/RichText/Heading.tsx
@@ -13,8 +13,7 @@ interface Props {
 
 function extractText(children: HeadingNode['children']): string {
     return children
-        .map((child) => ('text' in child ? child.text : extractText((child as any).children ?? []))
-        )
+        .map((child) => ('text' in child ? child.text : extractText((child as any).children ?? [])))
         .join('');
 }
 
@@ -31,8 +30,16 @@ export function Heading({ node, children }: Props) {
     const id = slugifyHeading(extractText(node.children));
 
     if (node.type === HeadingNode.Type.HEADING_ONE) {
-        return <h3 id={id} className={className}>{children}</h3>;
+        return (
+            <h3 id={id} className={className}>
+                {children}
+            </h3>
+        );
     }
 
-    return <h4 id={id} className={className}>{children}</h4>;
+    return (
+        <h4 id={id} className={className}>
+            {children}
+        </h4>
+    );
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,4 +15,5 @@ export { parseOffset } from './parseOffset';
 export { parsePreviewSearchParams } from './parsePreviewSearchParams';
 export { decodePreviewHash } from './previewLink';
 export * from './previewUtils';
+export { slugifyHeading } from './slugifyHeading';
 export { withoutUndefined } from './withoutUndefined';

--- a/src/utils/slugifyHeading.ts
+++ b/src/utils/slugifyHeading.ts
@@ -1,0 +1,8 @@
+export function slugifyHeading(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-')
+        .trim();
+}


### PR DESCRIPTION
- Adds id attributes to rendered h3/h4 heading elements in story content, using slugified versions of the heading text. This enables anchor linking directly to specific sections within a story.