### PR TITLE
[DEV-22377] Feature - Support new Meilisearch index

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@prezly/content-renderer-react-js": "0.44.0",
         "@prezly/sdk": "23.17.0",
         "@prezly/story-content-format": "0.70.0",
-        "@prezly/theme-kit-nextjs": "10.6.2",
+        "@prezly/theme-kit-nextjs": "10.6.3-beta.0",
         "@prezly/uploadcare": "2.6.0",
         "@prezly/uploadcare-image": "0.3.2",
         "@react-hookz/web": "14.7.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@prezly/content-renderer-react-js": "0.44.0",
         "@prezly/sdk": "23.17.0",
         "@prezly/story-content-format": "0.70.0",
-        "@prezly/theme-kit-nextjs": "10.6.3-beta.0",
+        "@prezly/theme-kit-nextjs": "10.7.0",
         "@prezly/uploadcare": "2.6.0",
         "@prezly/uploadcare-image": "0.3.2",
         "@react-hookz/web": "14.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 0.70.0
         version: 0.70.0
       '@prezly/theme-kit-nextjs':
-        specifier: 10.6.2
-        version: 10.6.2(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 10.6.3-beta.0
+        version: 10.6.3-beta.0(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@prezly/uploadcare':
         specifier: 2.6.0
         version: 2.6.0
@@ -799,24 +799,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.4':
     resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.4':
     resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.4':
     resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.4':
     resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
@@ -904,89 +908,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1198,24 +1218,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.12':
     resolution: {integrity: sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.12':
     resolution: {integrity: sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.12':
     resolution: {integrity: sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.12':
     resolution: {integrity: sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==}
@@ -1464,36 +1488,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -1572,8 +1602,8 @@ packages:
   '@prezly/story-content-format@0.70.1':
     resolution: {integrity: sha512-q5nwvlz161PsSB0nTBUBzXPHIgV+8euCCPHGB6NUUNpIpkM2JD9lp8zJnETs2REcOhsTaPMw/oum9Mbp2Qvk4A==}
 
-  '@prezly/theme-kit-core@10.6.2':
-    resolution: {integrity: sha512-wNIvY2m0cVUt8tTdaJ/daEBf4myZSa6VQkTnObBIrin4CLc+0rbFY6YlNQUcCyYl3tWCHmGe9sZMhqpDMZq3Ag==}
+  '@prezly/theme-kit-core@10.6.3-beta.0':
+    resolution: {integrity: sha512-awYv2wBG23zxTdx5Ao+nW8W3HUUZ5/xyJMB/YtjNeMMS0fcTOwuPECKd5eg4NLZJLJZb1JPph/wSniglTkkg3Q==}
     engines: {node: '>= 16.x', npm: '>= 8.x'}
     peerDependencies:
       '@prezly/sdk': 21.12.0 || ^23.x
@@ -1582,8 +1612,8 @@ packages:
     resolution: {integrity: sha512-/rkif1Tq92EtLF2IcIV1PhitwIWpH3uk9dabGhYHZUorPWFbwCKoQqpZV0xk0gXh7UO0uQuzcpQRBWaeJTQFVA==}
     engines: {node: '>= 14.x', npm: '>= 7.x'}
 
-  '@prezly/theme-kit-nextjs@10.6.2':
-    resolution: {integrity: sha512-6T2s29d4cvZdp5RFOOBpkZzpvxfdFcaCxsHSMBCAGuOfttLftpJdZbGqu4DhMsCi1aSVPj4LJ+J02Ao4Ypns9w==}
+  '@prezly/theme-kit-nextjs@10.6.3-beta.0':
+    resolution: {integrity: sha512-+rgt/Qpsgvfow8DYZN80Qs2wvTCSnptUzWQzZxrVapDcZuW13GpkKqPvaN9eYs9Dvo7ptuUkAUAKr7VYYF/ymQ==}
     engines: {node: '>= 16.x', npm: '>= 8.x'}
     peerDependencies:
       '@playwright/test': 1.x
@@ -1770,51 +1800,61 @@ packages:
     resolution: {integrity: sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.35.0':
     resolution: {integrity: sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.35.0':
     resolution: {integrity: sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.35.0':
     resolution: {integrity: sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.35.0':
     resolution: {integrity: sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.35.0':
     resolution: {integrity: sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.35.0':
     resolution: {integrity: sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.35.0':
     resolution: {integrity: sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.35.0':
     resolution: {integrity: sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.35.0':
     resolution: {integrity: sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.35.0':
     resolution: {integrity: sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==}
@@ -6050,7 +6090,7 @@ snapshots:
       '@prezly/uploads': 0.2.1
       is-plain-object: 5.0.0
 
-  '@prezly/theme-kit-core@10.6.2(@prezly/sdk@23.17.0)':
+  '@prezly/theme-kit-core@10.6.3-beta.0(@prezly/sdk@23.17.0)':
     dependencies:
       '@prezly/sdk': 23.17.0
       '@prezly/theme-kit-intl': 10.6.2
@@ -6064,10 +6104,10 @@ snapshots:
     dependencies:
       '@technically/is-not-undefined': 1.0.0
 
-  '@prezly/theme-kit-nextjs@10.6.2(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@prezly/theme-kit-nextjs@10.6.3-beta.0(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@prezly/sdk': 23.17.0
-      '@prezly/theme-kit-core': 10.6.2(@prezly/sdk@23.17.0)
+      '@prezly/theme-kit-core': 10.6.3-beta.0(@prezly/sdk@23.17.0)
       '@prezly/theme-kit-intl': 10.6.2
       '@prezly/theme-kit-react': 10.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@technically/is-not-undefined': 1.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: 0.70.0
         version: 0.70.0
       '@prezly/theme-kit-nextjs':
-        specifier: 10.6.3-beta.0
-        version: 10.6.3-beta.0(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 10.7.0
+        version: 10.7.0(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@prezly/uploadcare':
         specifier: 2.6.0
         version: 2.6.0
@@ -1602,8 +1602,8 @@ packages:
   '@prezly/story-content-format@0.70.1':
     resolution: {integrity: sha512-q5nwvlz161PsSB0nTBUBzXPHIgV+8euCCPHGB6NUUNpIpkM2JD9lp8zJnETs2REcOhsTaPMw/oum9Mbp2Qvk4A==}
 
-  '@prezly/theme-kit-core@10.6.3-beta.0':
-    resolution: {integrity: sha512-awYv2wBG23zxTdx5Ao+nW8W3HUUZ5/xyJMB/YtjNeMMS0fcTOwuPECKd5eg4NLZJLJZb1JPph/wSniglTkkg3Q==}
+  '@prezly/theme-kit-core@10.7.0':
+    resolution: {integrity: sha512-RZL2DbWpBwIqEj+c3SOp9Vx6Mry9Djx0+y1x5OFlToz//A/kEiq1dxosuE/fO0IFz674e7rk8+kkR4QGlpdDYA==}
     engines: {node: '>= 16.x', npm: '>= 8.x'}
     peerDependencies:
       '@prezly/sdk': 21.12.0 || ^23.x
@@ -1612,8 +1612,8 @@ packages:
     resolution: {integrity: sha512-/rkif1Tq92EtLF2IcIV1PhitwIWpH3uk9dabGhYHZUorPWFbwCKoQqpZV0xk0gXh7UO0uQuzcpQRBWaeJTQFVA==}
     engines: {node: '>= 14.x', npm: '>= 7.x'}
 
-  '@prezly/theme-kit-nextjs@10.6.3-beta.0':
-    resolution: {integrity: sha512-+rgt/Qpsgvfow8DYZN80Qs2wvTCSnptUzWQzZxrVapDcZuW13GpkKqPvaN9eYs9Dvo7ptuUkAUAKr7VYYF/ymQ==}
+  '@prezly/theme-kit-nextjs@10.7.0':
+    resolution: {integrity: sha512-JUHitkWk7SupDm+QjZxhjREdzivV7WKaov88CemKJF4A9SkL2UP6ap4fiW9b98Vg605DnJU5qByznwM8l+7gdA==}
     engines: {node: '>= 16.x', npm: '>= 8.x'}
     peerDependencies:
       '@playwright/test': 1.x
@@ -6090,7 +6090,7 @@ snapshots:
       '@prezly/uploads': 0.2.1
       is-plain-object: 5.0.0
 
-  '@prezly/theme-kit-core@10.6.3-beta.0(@prezly/sdk@23.17.0)':
+  '@prezly/theme-kit-core@10.7.0(@prezly/sdk@23.17.0)':
     dependencies:
       '@prezly/sdk': 23.17.0
       '@prezly/theme-kit-intl': 10.6.2
@@ -6104,10 +6104,10 @@ snapshots:
     dependencies:
       '@technically/is-not-undefined': 1.0.0
 
-  '@prezly/theme-kit-nextjs@10.6.3-beta.0(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@prezly/theme-kit-nextjs@10.7.0(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@prezly/sdk': 23.17.0
-      '@prezly/theme-kit-core': 10.6.3-beta.0(@prezly/sdk@23.17.0)
+      '@prezly/theme-kit-core': 10.7.0(@prezly/sdk@23.17.0)
       '@prezly/theme-kit-intl': 10.6.2
       '@prezly/theme-kit-react': 10.6.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@technically/is-not-undefined': 1.0.0

--- a/src/adapters/server/search.ts
+++ b/src/adapters/server/search.ts
@@ -6,7 +6,7 @@ export function getSearchSettings(): SearchSettings | undefined {
     const {
         MEILISEARCH_API_KEY = '',
         MEILISEARCH_HOST = 'https://search.prezly.com',
-        MEILISEARCH_INDEX = 'public_stories',
+        MEILISEARCH_INDEX = 'public_stories_v2',
     } = environment();
 
     if (MEILISEARCH_API_KEY && MEILISEARCH_HOST && MEILISEARCH_INDEX) {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -16,7 +16,7 @@ export function Link({
 
     const renderedHref =
         typeof href === 'object' && 'routeName' in href
-            ? generateUrl(href.routeName, href.params ?? {})
+            ? generateUrl(href.routeName, href.params ?? {}) + (href.hash ?? '')
             : href;
 
     if (forceRefresh) {
@@ -38,7 +38,7 @@ export namespace Link {
     export interface Props
         extends Omit<NextLinkProps, 'href'>,
             Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
-        href: string | AppUrlGeneratorParams;
+        href: string | (AppUrlGeneratorParams & { hash?: string });
         children?: ReactNode;
         forceRefresh?: boolean;
         forwardRef?: Ref<HTMLAnchorElement>;

--- a/src/components/StoryCards/StoryCard.tsx
+++ b/src/components/StoryCards/StoryCard.tsx
@@ -12,6 +12,7 @@ import { StoryImage } from '../StoryImage';
 import styles from './StoryCard.module.scss';
 
 type Props = {
+    anchor?: string;
     className?: string;
     external: ExternalStoryUrl;
     fallback: StoryImage.Props['fallback'];
@@ -33,6 +34,7 @@ type Props = {
 };
 
 export function StoryCard({
+    anchor,
     className,
     external,
     fallback,
@@ -56,8 +58,8 @@ export function StoryCard({
     const HeadingTag = size === 'small' ? 'h3' : 'h2';
 
     const href = external
-        ? external.storyUrl
-        : ({ routeName: 'story', params: { slug } } satisfies Link.Props['href']);
+        ? `${external.storyUrl}${anchor ?? ''}`
+        : ({ routeName: 'story', params: { slug }, hash: anchor } satisfies Link.Props['href']);
 
     return (
         <div

--- a/src/modules/Header/ui/SearchWidget/components/MainPanel.tsx
+++ b/src/modules/Header/ui/SearchWidget/components/MainPanel.tsx
@@ -8,7 +8,7 @@ import { SearchResults } from './SearchResults';
 
 import styles from './MainPanel.module.scss';
 
-interface Props extends StateResultsProvided<Search.IndexedStory> {
+interface Props extends StateResultsProvided<Search.IndexedStorySection> {
     categories: TranslatedCategory[];
     isSearchPage: boolean;
     newsrooms: Newsroom[];

--- a/src/modules/Header/ui/SearchWidget/components/SearchHit.tsx
+++ b/src/modules/Header/ui/SearchWidget/components/SearchHit.tsx
@@ -7,13 +7,13 @@ import { Highlight } from 'react-instantsearch-dom';
 import { Link } from '@/components/Link';
 import { StoryImage } from '@/components/StoryImage';
 import type { ExternalStoryUrl } from '@/types';
-import { getNewsroomPlaceholderColors } from '@/utils';
+import { getNewsroomPlaceholderColors, slugifyHeading } from '@/utils';
 
 import styles from './SearchHit.module.scss';
 
 interface Props {
     external: ExternalStoryUrl;
-    hit: Hit<{ attributes: Search.IndexedStory; _tags: string[] }>;
+    hit: Hit<{ attributes: Search.IndexedStorySection; _tags: string[] }>;
     newsroom: Newsroom | undefined;
     onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
 }
@@ -21,9 +21,12 @@ interface Props {
 export function SearchHit({ external, hit, newsroom, onClick }: Props) {
     const { attributes: story } = hit;
 
+    const sectionHeading = story.section_title ?? story.section_subtitle;
+    const hash = sectionHeading ? `#header-${slugifyHeading(sectionHeading)}` : undefined;
+
     const href = external
-        ? external.storyUrl
-        : ({ routeName: 'story', params: story } satisfies Link.Props['href']);
+        ? `${external.storyUrl}${hash ?? ''}`
+        : ({ routeName: 'story', params: story, hash } satisfies Link.Props['href']);
 
     return (
         <Link href={href} className={styles.container} onClick={onClick}>

--- a/src/modules/Header/ui/SearchWidget/components/SearchResults.tsx
+++ b/src/modules/Header/ui/SearchWidget/components/SearchResults.tsx
@@ -17,7 +17,7 @@ import { SearchHit } from './SearchHit';
 
 import styles from './MainPanel.module.scss';
 
-interface Props extends Pick<StateResultsProvided<Search.IndexedStory>, 'searchResults'> {
+interface Props extends Pick<StateResultsProvided<Search.IndexedStorySection>, 'searchResults'> {
     newsrooms: Newsroom[];
     newsroomUuid: string;
     query?: string;
@@ -46,8 +46,7 @@ export function SearchResults({
                 newsroom && newsroom.uuid !== newsroomUuid
                     ? ({
                           newsroomUrl: newsroom.url,
-                          // TODO: Add the URL here when it's available in Meilisearch
-                          storyUrl: '',
+                          storyUrl: hit.attributes.url ?? '',
                       } satisfies ExternalStoryUrl)
                     : false;
 

--- a/src/modules/Search/components/Hit.tsx
+++ b/src/modules/Search/components/Hit.tsx
@@ -10,11 +10,11 @@ import { useLocale } from '@/adapters/client';
 import { StoryCard } from '@/components/StoryCards';
 import type { ThemeSettings } from '@/theme-settings';
 import type { ExternalStoryUrl } from '@/types';
-import { getNewsroomPlaceholderColors } from '@/utils';
+import { getNewsroomPlaceholderColors, slugifyHeading } from '@/utils';
 
 export interface Props {
     external: ExternalStoryUrl;
-    hit: HitType<{ attributes: Search.IndexedStory; _tags: string[] }>;
+    hit: HitType<{ attributes: Search.IndexedStorySection; _tags: string[] }>;
     newsroom: Newsroom;
     showDate: boolean;
     showSubtitle: boolean;
@@ -41,8 +41,12 @@ export function Hit({ external, hit, newsroom, showDate, showSubtitle, storyCard
         [localeCode, categories],
     );
 
+    const sectionHeading = story.section_title ?? story.section_subtitle;
+    const anchor = sectionHeading ? `#header-${slugifyHeading(sectionHeading)}` : undefined;
+
     return (
         <StoryCard
+            anchor={anchor}
             external={external}
             fallback={{
                 image: newsroom.newsroom_logo,

--- a/src/modules/Search/components/Results.tsx
+++ b/src/modules/Search/components/Results.tsx
@@ -70,8 +70,7 @@ export const Results = connectInfiniteHits(
                             newsroom.uuid !== newsroomUuid
                                 ? ({
                                       newsroomUrl: newsroom.url,
-                                      // TODO: Add the URL here when it's available in Meilisearch
-                                      storyUrl: '',
+                                      storyUrl: hit.attributes.url ?? '',
                                   } satisfies ExternalStoryUrl)
                                 : false;
 


### PR DESCRIPTION
Based on prezly/theme-kit-js#1025

- Upgraded `@prezly/theme-kit-nextjs` to `10.6.3-beta.0`, which adds the `IndexedStorySection` type with `section_title`, `section_subtitle`, and `url` fields
- Added `hash` support to the `Link` component's route object href, enabling anchor navigation via internal routes
- Added an `anchor` prop to `StoryCard` that appends to the story URL for both internal and external links
- Updated the search results page and search widget to use `IndexedStorySection`, compute an anchor from `section_title` (falling back to `section_subtitle`), and link directly to the matched section using `#header-{slug}`
- Fixed external cross-newsroom story URLs in both search results and search widget to use the `url` field from the index instead of an empty string
- Changed the default MeiliSearch index to `public_stories_v2`