### PR TITLE
DEV-23074: Add hidecookie query param for preview logic

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export const CDN_URL = `https://${process.env.NEXT_PUBLIC_UPLOADCARE_CUSTOM_CDN_DOMAIN}`;
 export const PREVIEW_COOKIE = 'theme-nextjs-bea-preview';
 export const PREVIEW_SEARCH_PARAM = 'preview';
+export const HIDECOOKIE_SEARCH_PARAM = 'hidecookie';
 
 export const MAX_SAFE_INT = 2147483648; // Max signed 32bit int.

--- a/src/modules/CookieConsent/components/OneTrustCookie/OneTrustCookie.tsx
+++ b/src/modules/CookieConsent/components/OneTrustCookie/OneTrustCookie.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { isPreviewActive } from '@/utils';
+import { isHideCookieActive, isPreviewActive } from '@/utils';
 
 import { ONETRUST_INTEGRATION_EVENT } from './constants';
 import { OneTrustManager } from './OneTrustManager';
@@ -26,7 +26,7 @@ interface Props {
 }
 
 export function OneTrustCookie({ script, category }: Props) {
-    const isPreview = isPreviewActive();
+    const isPreview = isPreviewActive() || isHideCookieActive();
 
     return (
         <>

--- a/src/modules/CookieConsent/components/VanillaCookieConsent/VanillaCookieConsent.tsx
+++ b/src/modules/CookieConsent/components/VanillaCookieConsent/VanillaCookieConsent.tsx
@@ -5,7 +5,7 @@ import { useEffect } from 'react';
 import * as CookieConsent from 'vanilla-cookieconsent';
 import 'vanilla-cookieconsent/dist/cookieconsent.css';
 
-import { isPreviewActive } from '@/utils';
+import { isHideCookieActive, isPreviewActive } from '@/utils';
 
 import { useCookieConsent } from '../../CookieConsentContext';
 import { ConsentCategory } from '../../types';
@@ -23,6 +23,8 @@ export function VanillaCookieConsent({ cookieStatement }: Props) {
     const { formatMessage } = useIntl();
     const { setConsent, registerUpdatePreferencesCallback } = useCookieConsent();
     const isPreview = isPreviewActive();
+    const hideCookie = isHideCookieActive();
+    const shouldHideCookieBanner = isPreview || hideCookie;
 
     const policyLinksHtml = `\
         <p>
@@ -38,7 +40,7 @@ export function VanillaCookieConsent({ cookieStatement }: Props) {
 
     useEffect(() => {
         CookieConsent.run({
-            autoShow: !isPreview,
+            autoShow: !shouldHideCookieBanner,
             cookie: {
                 useLocalStorage: true,
             },
@@ -136,7 +138,7 @@ export function VanillaCookieConsent({ cookieStatement }: Props) {
                 }));
             },
         });
-    }, [cookieStatement, formatMessage, isPreview, policyLinksHtml, setConsent]);
+    }, [cookieStatement, formatMessage, shouldHideCookieBanner, policyLinksHtml, setConsent]);
 
     useEffect(() => {
         const consentCategories = CookieConsent.getUserPreferences().acceptedCategories;
@@ -147,7 +149,7 @@ export function VanillaCookieConsent({ cookieStatement }: Props) {
     }, [setConsent]);
 
     useEffect(() => {
-        if (isPreview) {
+        if (shouldHideCookieBanner) {
             const categories = [
                 ConsentCategory.FIRST_PARTY_ANALYTICS,
                 ConsentCategory.NECESSARY,
@@ -156,7 +158,7 @@ export function VanillaCookieConsent({ cookieStatement }: Props) {
             CookieConsent.acceptCategory(categories);
             setConsent({ categories });
         }
-    }, [isPreview, setConsent]);
+    }, [shouldHideCookieBanner, setConsent]);
 
     useEffect(() => {
         registerUpdatePreferencesCallback(() => {

--- a/src/utils/previewUtils.ts
+++ b/src/utils/previewUtils.ts
@@ -1,6 +1,6 @@
 import Cookies from 'js-cookie';
 
-import { PREVIEW_COOKIE, PREVIEW_SEARCH_PARAM } from '@/constants';
+import { HIDECOOKIE_SEARCH_PARAM, PREVIEW_COOKIE, PREVIEW_SEARCH_PARAM } from '@/constants';
 
 const PREVIEW_COOKIE_DURATION_MINUTES = 30;
 
@@ -30,6 +30,15 @@ export function isPreviewActive(): boolean {
     }
 
     return false;
+}
+
+export function isHideCookieActive(): boolean {
+    if (typeof window === 'undefined') {
+        return false;
+    }
+
+    const url = new URL(window.location.href);
+    return url.searchParams.get(HIDECOOKIE_SEARCH_PARAM) === 'true';
 }
 
 export function clearPreview(): void {


### PR DESCRIPTION
Add `?hidecookie=true` query param support that hides the cookie consent banner (both Vanilla and OneTrust) without showing the preview bar. This allows in-app iframe previews to use `?mask=true&hidecookie=true` to block clicks and hide the cookie banner, while keeping the preview bar hidden.

