### PR TITLE
[DEV-23048] Feature - Incorporate in-page sections in search results display

### DIFF
--- a/src/modules/Header/ui/SearchWidget/SearchWidget.tsx
+++ b/src/modules/Header/ui/SearchWidget/SearchWidget.tsx
@@ -51,7 +51,19 @@ export function SearchWidget({
             backdropClassName={styles.backdrop}
         >
             <InstantSearch searchClient={searchClient} indexName={settings.index}>
-                <Configure hitsPerPage={3} filters={filters} />
+                <Configure
+                    hitsPerPage={3}
+                    filters={filters}
+                    attributesToHighlight={[
+                        'attributes.title',
+                        'attributes.subtitle',
+                        'attributes.section_title',
+                        'attributes.section_subtitle',
+                        'attributes.content_text',
+                    ]}
+                    attributesToSnippet={['attributes.content_text:30']}
+                    snippetEllipsisText="…"
+                />
                 <SearchBar />
                 <MainPanel
                     categories={categories}

--- a/src/modules/Header/ui/SearchWidget/components/SearchHit.module.scss
+++ b/src/modules/Header/ui/SearchWidget/components/SearchHit.module.scss
@@ -1,6 +1,6 @@
 .container {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     color: inherit;
     text-decoration: none;
 
@@ -25,6 +25,14 @@
     @include border-radius-s;
 }
 
+.content {
+    display: flex;
+    flex-direction: column;
+    gap: $spacing-1;
+    min-width: 0;
+    flex: 1;
+}
+
 .title {
     @include text-label;
     @include line-clamp(2);
@@ -33,4 +41,28 @@
     & {
         font-weight: $font-weight-semi-bold;
     }
+}
+
+.snippet {
+    @include text-small;
+    @include line-clamp(2);
+
+    & {
+        color: var(--prezly-text-color-tertiary);
+    }
+
+    mark {
+        background: transparent;
+        color: inherit;
+        font-weight: $font-weight-semi-bold;
+    }
+}
+
+.section {
+    color: var(--prezly-text-color-secondary);
+    font-weight: $font-weight-semi-bold;
+}
+
+.separator {
+    color: var(--prezly-text-color-tertiary);
 }

--- a/src/modules/Header/ui/SearchWidget/components/SearchHit.module.scss
+++ b/src/modules/Header/ui/SearchWidget/components/SearchHit.module.scss
@@ -40,6 +40,7 @@
 
     & {
         font-weight: $font-weight-semi-bold;
+        margin: 0;
     }
 }
 
@@ -49,11 +50,12 @@
 
     & {
         color: var(--prezly-text-color-tertiary);
+        margin: 0;
     }
 
     mark {
         background: transparent;
-        color: inherit;
+        color: var(--prezly-text-color-secondary);
         font-weight: $font-weight-semi-bold;
     }
 }

--- a/src/modules/Header/ui/SearchWidget/components/SearchHit.tsx
+++ b/src/modules/Header/ui/SearchWidget/components/SearchHit.tsx
@@ -2,7 +2,7 @@ import type { Newsroom } from '@prezly/sdk';
 import type { Search } from '@prezly/theme-kit-nextjs';
 import type { MouseEvent } from 'react';
 import type { Hit } from 'react-instantsearch-core';
-import { Highlight } from 'react-instantsearch-dom';
+import { Highlight, Snippet } from 'react-instantsearch-dom';
 
 import { Link } from '@/components/Link';
 import { StoryImage } from '@/components/StoryImage';
@@ -22,11 +22,16 @@ export function SearchHit({ external, hit, newsroom, onClick }: Props) {
     const { attributes: story } = hit;
 
     const sectionHeading = story.section_title ?? story.section_subtitle;
+    const sectionHeadingAttribute = story.section_title
+        ? 'attributes.section_title'
+        : 'attributes.section_subtitle';
     const hash = sectionHeading ? `#header-${slugifyHeading(sectionHeading)}` : undefined;
 
     const href = external
         ? `${external.storyUrl}${hash ?? ''}`
         : ({ routeName: 'story', params: story, hash } satisfies Link.Props['href']);
+
+    const hasSnippet = Boolean(story.content_text);
 
     return (
         <Link href={href} className={styles.container} onClick={onClick}>
@@ -44,9 +49,30 @@ export function SearchHit({ external, hit, newsroom, onClick }: Props) {
                     title={story.title}
                 />
             </div>
-            <p className={styles.title}>
-                <Highlight hit={hit} attribute="attributes.title" tagName="mark" />
-            </p>
+            <div className={styles.content}>
+                <p className={styles.title}>
+                    <Highlight hit={hit} attribute="attributes.title" tagName="mark" />
+                </p>
+                {(sectionHeading || hasSnippet) && (
+                    <p className={styles.snippet}>
+                        {sectionHeading && (
+                            <span className={styles.section}>
+                                <Highlight
+                                    hit={hit}
+                                    attribute={sectionHeadingAttribute}
+                                    tagName="mark"
+                                />
+                            </span>
+                        )}
+                        {sectionHeading && hasSnippet && (
+                            <span className={styles.separator}> · </span>
+                        )}
+                        {hasSnippet && (
+                            <Snippet hit={hit} attribute="attributes.content_text" tagName="mark" />
+                        )}
+                    </p>
+                )}
+            </div>
         </Link>
     );
 }

--- a/src/modules/Search/Search.tsx
+++ b/src/modules/Search/Search.tsx
@@ -68,7 +68,19 @@ export function Search({
             onSearchStateChange={onSearchStateChange}
             createURL={createUrl}
         >
-            <Configure hitsPerPage={6} filters={filters} />
+            <Configure
+                hitsPerPage={6}
+                filters={filters}
+                attributesToHighlight={[
+                    'attributes.title',
+                    'attributes.subtitle',
+                    'attributes.section_title',
+                    'attributes.section_subtitle',
+                    'attributes.content_text',
+                ]}
+                attributesToSnippet={['attributes.content_text:30']}
+                snippetEllipsisText="…"
+            />
             <SearchStateContextProvider>
                 <Title />
                 <SearchBar />

--- a/src/modules/Search/components/Hit.module.scss
+++ b/src/modules/Search/components/Hit.module.scss
@@ -1,0 +1,18 @@
+.snippet {
+    display: block;
+
+    mark {
+        background: transparent;
+        color: inherit;
+        font-weight: $font-weight-semi-bold;
+    }
+}
+
+.section {
+    color: var(--prezly-text-color-secondary);
+    font-weight: $font-weight-semi-bold;
+}
+
+.separator {
+    color: var(--prezly-text-color-tertiary);
+}

--- a/src/modules/Search/components/Hit.tsx
+++ b/src/modules/Search/components/Hit.tsx
@@ -4,13 +4,17 @@ import type { Newsroom, TranslatedCategory } from '@prezly/sdk';
 import type { Search } from '@prezly/theme-kit-nextjs';
 import { useMemo } from 'react';
 import type { Hit as HitType } from 'react-instantsearch-core';
-import { Highlight } from 'react-instantsearch-dom';
+import { Highlight, Snippet } from 'react-instantsearch-dom';
 
 import { useLocale } from '@/adapters/client';
 import { StoryCard } from '@/components/StoryCards';
 import type { ThemeSettings } from '@/theme-settings';
 import type { ExternalStoryUrl } from '@/types';
 import { getNewsroomPlaceholderColors, slugifyHeading } from '@/utils';
+
+import { useSearchState } from './SearchStateContext';
+
+import styles from './Hit.module.scss';
 
 export interface Props {
     external: ExternalStoryUrl;
@@ -25,6 +29,7 @@ export function Hit({ external, hit, newsroom, showDate, showSubtitle, storyCard
     const { attributes: story } = hit;
     const { categories } = story;
     const localeCode = useLocale();
+    const { searchState } = useSearchState();
 
     const displayedCategories: TranslatedCategory[] = useMemo(
         () =>
@@ -42,7 +47,34 @@ export function Hit({ external, hit, newsroom, showDate, showSubtitle, storyCard
     );
 
     const sectionHeading = story.section_title ?? story.section_subtitle;
+    const sectionHeadingAttribute = story.section_title
+        ? 'attributes.section_title'
+        : 'attributes.section_subtitle';
     const anchor = sectionHeading ? `#header-${slugifyHeading(sectionHeading)}` : undefined;
+
+    const hasQuery = Boolean(searchState.query?.trim());
+    const hasContentSnippet = Boolean(story.content_text);
+    const showSectionSnippet = hasQuery && (Boolean(sectionHeading) || hasContentSnippet);
+
+    const subtitle = showSectionSnippet ? (
+        <span className={styles.snippet}>
+            {sectionHeading && (
+                <span className={styles.section}>
+                    <Highlight hit={hit} attribute={sectionHeadingAttribute} tagName="mark" />
+                </span>
+            )}
+            {sectionHeading && hasContentSnippet && <span className={styles.separator}> · </span>}
+            {hasContentSnippet && (
+                <Snippet hit={hit} attribute="attributes.content_text" tagName="mark" />
+            )}
+        </span>
+    ) : (
+        story.subtitle
+    );
+
+    // Force the subtitle slot on when we have a section snippet, even if the
+    // theme has `show_subtitle` disabled — it is the matched context.
+    const showSubtitleEffective = showSubtitle || showSectionSnippet;
 
     return (
         <StoryCard
@@ -56,10 +88,10 @@ export function Hit({ external, hit, newsroom, showDate, showSubtitle, storyCard
             placeholder={getNewsroomPlaceholderColors(newsroom)}
             publishedAt={new Date(story.published_at * 1000).toISOString()}
             showDate={showDate}
-            showSubtitle={showSubtitle}
+            showSubtitle={showSubtitleEffective}
             size="small"
             slug={story.slug}
-            subtitle={story.subtitle}
+            subtitle={subtitle}
             thumbnailImage={story.thumbnail_image}
             title={<Highlight hit={hit} attribute="attributes.title" tagName="mark" />}
             titleAsString={hit.attributes.title}

--- a/src/modules/Search/components/SearchStateContext.tsx
+++ b/src/modules/Search/components/SearchStateContext.tsx
@@ -6,14 +6,14 @@ import { createContext, useContext } from 'react';
 import type { StateResultsProvided } from 'react-instantsearch-core';
 import { connectStateResults } from 'react-instantsearch-dom';
 
-const SearchStateContext = createContext<StateResultsProvided<Search.IndexedStory> | undefined>(
-    undefined,
-);
+const SearchStateContext = createContext<
+    StateResultsProvided<Search.IndexedStorySection> | undefined
+>(undefined);
 
 function SearchStateContextProvider({
     children,
     ...contextValue
-}: PropsWithChildren<StateResultsProvided<Search.IndexedStory>>) {
+}: PropsWithChildren<StateResultsProvided<Search.IndexedStorySection>>) {
     return (
         <SearchStateContext.Provider value={contextValue}>{children}</SearchStateContext.Provider>
     );


### PR DESCRIPTION
* Configured attributesToHighlight on `attributes.title`, `attributes.subtitle`, `attributes.section_title`, `attributes.section_subtitle`, and `attributes.content_text` so Meili wraps matches with highlight markers in all the rendered fields.
* Configured attributesToSnippet (mapped by instant-meilisearch to Meili's attributesToCrop) as `attributes.content_text:30` with snippetEllipsisText="…" so the body is returned cropped to \~30 words centered on the match instead of the full article text.
* Rendered the same section heading + body snippet in place of the story subtitle on the dedicated search page when the user has a query; falls back to the original story subtitle when the query is empty (facet-only browsing).
* Forced the StoryCard subtitle slot on when surfacing a section snippet so the matched context is visible even if the theme has `show_subtitle` disabled.
* Kept the existing `#header-${slugifyHeading(section_title ?? section_subtitle)}` anchor logic for deep-linking into the matched section

https://github.com/user-attachments/assets/c488bfe2-a71d-4ba4-801f-7b83517b275a