### PR TITLE
chore: add font antialiasing to body

### DIFF
--- a/src/styles/_typography.scss
+++ b/src/styles/_typography.scss
@@ -6,6 +6,8 @@ body {
     color: var(--prezly-text-color);
     word-break: break-word;
     background: var(--prezly-background-color);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
 }
 
 h1,


### PR DESCRIPTION
Applies -webkit-font-smoothing: antialiased and -moz-osx-font-smoothing: grayscale to the body element, enabling grayscale anti-aliasing for text rendering on macOS across all browsers. 

**This produces crisper, lighter-weight text compared to the default subpixel rendering.**