### PR TITLE
Increase nav bar and sub-footer max-width to 1920px

### DIFF
--- a/src/modules/Footer/ui/Footer.module.scss
+++ b/src/modules/Footer/ui/Footer.module.scss
@@ -6,6 +6,10 @@
     background: var(--prezly-footer-background-color);
 }
 
+.inner {
+    @include container(1920px);
+}
+
 .footer {
     display: flex;
     align-items: center;

--- a/src/modules/Footer/ui/Footer.tsx
+++ b/src/modules/Footer/ui/Footer.tsx
@@ -27,7 +27,7 @@ export function Footer({ children, ...props }: Props) {
 
     return (
         <footer className={styles.container}>
-            <div className="container">
+            <div className={styles.inner}>
                 <div className={styles.footer}>
                     <div className={styles.links}>{children}</div>
                     {!isWhiteLabeled && <MadeWithPrezly />}

--- a/src/modules/Header/ui/Header.module.scss
+++ b/src/modules/Header/ui/Header.module.scss
@@ -7,6 +7,10 @@ $header-height: 88px;
     z-index: 3;
 }
 
+.inner {
+    @include container(1920px);
+}
+
 .header {
     display: flex;
     align-items: center;

--- a/src/modules/Header/ui/Header.tsx
+++ b/src/modules/Header/ui/Header.tsx
@@ -208,7 +208,7 @@ export function Header({
     return (
         <>
             <header ref={headerRef} className={styles.container}>
-                <div className="container">
+                <div className={styles.inner}>
                     <nav className={styles.header}>
                         {isPreview && !logo ? (
                             <LogoPlaceholder newsroom={newsroom} />

--- a/src/styles/mixins/_container.scss
+++ b/src/styles/mixins/_container.scss
@@ -1,7 +1,7 @@
 @use "../variables/spacing";
 @use "responsive";
 
-@mixin container {
+@mixin container($max-width: spacing.$grid-container-max-width) {
     width: 100%;
     margin-left: auto;
     margin-right: auto;
@@ -16,7 +16,7 @@
     @include responsive.desktop-up {
         padding-left: spacing.$grid-spacing-desktop;
         padding-right: spacing.$grid-spacing-desktop;
-        max-width: spacing.$grid-container-max-width;
+        max-width: $max-width;
     }
 }
 


### PR DESCRIPTION
- **_container.scss:** Added optional $max-width param to the mixin so consumers can override the default 1280px.
- **Header.tsx + Header.module.scss:** Swapped global .container for a local .inner class capped at 1920px.
- **Footer.tsx + Footer.module.scss:** Same as header.

**Before:**
<img width="1893" height="715" alt="CleanShot 2026-05-25 at 14 22 31" src="https://github.com/user-attachments/assets/cf79c3ec-56d9-4bca-942b-3659c1dbabfd" />
<img width="1879" height="811" alt="CleanShot 2026-05-25 at 14 24 00" src="https://github.com/user-attachments/assets/db4d9d03-864d-4dbf-a9c6-146c2eed66e1" />

After:
<img width="1891" height="601" alt="CleanShot 2026-05-25 at 14 23 10" src="https://github.com/user-attachments/assets/20a99432-00e1-4e2a-8abd-d1e0ed935d9d" />
<img width="1893" height="770" alt="CleanShot 2026-05-25 at 14 23 40" src="https://github.com/user-attachments/assets/7b34aca5-5310-4297-912a-5710441463c6" />

**⚠️ Base branch is theme-improvements, not main. Do not change it.**