### PR TITLE
Redirect to canonical URL when newsroom opts in

### DIFF
--- a/app/[localeCode]/(policies)/cookie-policy/page.tsx
+++ b/app/[localeCode]/(policies)/cookie-policy/page.tsx
@@ -13,8 +13,7 @@ interface Props {
 
 export async function generateMetadata(props: Props) {
     const { localeCode } = await props.params;
-    const { policies } = await app().newsroom();
-    const { cookie_policy: policy } = policies;
+    const { cookie_policy: policy } = await app().policies();
 
     if ('link' in policy) {
         redirect(policy.link);
@@ -29,8 +28,7 @@ export async function generateMetadata(props: Props) {
 }
 
 export default async function StoryPage() {
-    const { policies } = await app().newsroom();
-    const { cookie_policy: policy } = policies;
+    const { cookie_policy: policy } = await app().policies();
 
     if ('link' in policy) {
         redirect(policy.link);

--- a/app/[localeCode]/(policies)/privacy-policy/page.tsx
+++ b/app/[localeCode]/(policies)/privacy-policy/page.tsx
@@ -13,8 +13,7 @@ interface Props {
 
 export async function generateMetadata(props: Props) {
     const { localeCode } = await props.params;
-    const { policies } = await app().newsroom();
-    const { privacy_policy: policy } = policies;
+    const { privacy_policy: policy } = await app().policies();
 
     if ('link' in policy) {
         redirect(policy.link);
@@ -29,8 +28,7 @@ export async function generateMetadata(props: Props) {
 }
 
 export default async function StoryPage() {
-    const { policies } = await app().newsroom();
-    const { privacy_policy: policy } = policies;
+    const { privacy_policy: policy } = await app().policies();
 
     if ('link' in policy) {
         redirect(policy.link);

--- a/app/[localeCode]/(story)/[slug]/page.tsx
+++ b/app/[localeCode]/(story)/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { Story as StorySdk } from '@prezly/sdk';
 import type { Locale } from '@prezly/theme-kit-nextjs';
 import { notFound, permanentRedirect, redirect } from 'next/navigation';
 
@@ -25,9 +26,11 @@ async function resolve(params: Props['params']) {
         return redirect(configureAppRouter().generate('story', { slug: story.slug }));
     }
 
-    const newsroom = await app().newsroom();
-    if (newsroom.redirect_to_canonical_url && story.seo_settings.canonical_url) {
-        permanentRedirect(story.seo_settings.canonical_url);
+    if (story.visibility === StorySdk.Visibility.PUBLIC && story.seo_settings.canonical_url) {
+        const newsroom = await app().newsroom();
+        if (newsroom.redirect_to_canonical_url) {
+            permanentRedirect(story.seo_settings.canonical_url);
+        }
     }
 
     const { stories: relatedStories } = await app().stories({

--- a/app/[localeCode]/(story)/[slug]/page.tsx
+++ b/app/[localeCode]/(story)/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import type { Locale } from '@prezly/theme-kit-nextjs';
-import { notFound, redirect } from 'next/navigation';
+import { notFound, permanentRedirect, redirect } from 'next/navigation';
 
 import { app, configureAppRouter, generateStoryPageMetadata } from '@/adapters/server';
 import { Story } from '@/modules/Story';
@@ -23,6 +23,11 @@ async function resolve(params: Props['params']) {
 
     if (story.slug !== slug && encodeURIComponent(story.slug) !== slug) {
         return redirect(configureAppRouter().generate('story', { slug: story.slug }));
+    }
+
+    const newsroom = await app().newsroom();
+    if (newsroom.redirect_to_canonical_url && story.seo_settings.canonical_url) {
+        permanentRedirect(story.seo_settings.canonical_url);
     }
 
     const { stories: relatedStories } = await app().stories({

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@playwright/test": "^1.50.1",
         "@prezly/analytics-nextjs": "4.3.0",
         "@prezly/content-renderer-react-js": "0.44.3",
-        "@prezly/sdk": "23.17.0",
+        "@prezly/sdk": "26.5.0",
         "@prezly/story-content-format": "0.70.0",
         "@prezly/theme-kit-nextjs": "10.8.0",
         "@prezly/uploadcare": "2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,14 +31,14 @@ importers:
         specifier: 0.44.3
         version: 0.44.3(js-cookie@3.0.5)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@prezly/sdk':
-        specifier: 23.17.0
-        version: 23.17.0
+        specifier: 26.5.0
+        version: 26.5.0
       '@prezly/story-content-format':
         specifier: 0.70.0
         version: 0.70.0
       '@prezly/theme-kit-nextjs':
         specifier: 10.8.0
-        version: 10.8.0(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 10.8.0(@playwright/test@1.57.0)(@prezly/sdk@26.5.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@prezly/uploadcare':
         specifier: 2.6.0
         version: 2.6.0
@@ -799,28 +799,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.4':
     resolution: {integrity: sha512-M/Iz48p4NAzMXOuH+tsn5BvG/Jb07KOMTdSVwJpicmhN309BeEyRyQX+n1XDF0JVSlu28+hiTQ2L4rZPvu7nMw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.4':
     resolution: {integrity: sha512-m41nFDS0ksXK2gwXL6W6yZTYPMH0LughqbsxInSKetoH6morVj43szqKx79Iudkp8WRT5SxSh7qVb8KCUiewGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.4':
     resolution: {integrity: sha512-orr3nnf2Dpb2ssl6aihQtvcKtLySLta4E2UcXdp7+RTa7mfJjBgIsbS0B9GC8gVu0hjOu021aU8b3/I1tn+pVQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.4':
     resolution: {integrity: sha512-NXnfTeKHDFUWfxAefa57DiGmu9VyKi0cDqFpdI+1hJWQjGJhJutHPX0b5m+eXvTKOaf+brU+P0JrQAZMb5yYaQ==}
@@ -908,105 +904,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1218,28 +1198,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.12':
     resolution: {integrity: sha512-+fpGWvQiITgf7PUtbWY1H7qUSnBZsPPLyyq03QuAKpVoTy/QUx1JptEDTQMVvQhvizCEuNLEeghrQUyXQOekuw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.12':
     resolution: {integrity: sha512-jSLvgdRRL/hrFAPqEjJf1fFguC719kmcptjNVDJl26BnJIpjL3KH5h6mzR4mAweociLQaqvt4UyzfbFjgAdDcw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.12':
     resolution: {integrity: sha512-/uaF0WfmYqQgLfPmN6BvULwxY0dufI2mlN2JbOKqqceZh1G4hjREyi7pg03zjfyS6eqNemHAZPSoP84x17vo6w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.12':
     resolution: {integrity: sha512-xhsL1OvQSfGmlL5RbOmU+FV120urrgFpYLq+6U8C6KIym32gZT6XF/SDE92jKzzlPWskkbjOKCpqk5m4i8PEfg==}
@@ -1488,42 +1464,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -1594,6 +1564,10 @@ packages:
 
   '@prezly/sdk@23.17.0':
     resolution: {integrity: sha512-Fq4QnwCDd0hZi5Nmre9hElE0nhcPlLaLQHt/8uuDNu3/Z2Mmfk/3dvuqlE/8nxW1oBXjKVemwZN6bxCDsWuCOw==}
+    engines: {node: '>= 16'}
+
+  '@prezly/sdk@26.5.0':
+    resolution: {integrity: sha512-BlTtgyYGODYgVv7lxFRZbfaGZTkaj9DPFE1DREVoegIzPqmpAJ/mm5u2+u6BcuLMnn5m9H3lKvhA0pUj6LzDnQ==}
     engines: {node: '>= 16'}
 
   '@prezly/story-content-format@0.70.0':
@@ -1800,61 +1774,51 @@ packages:
     resolution: {integrity: sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.35.0':
     resolution: {integrity: sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.35.0':
     resolution: {integrity: sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.35.0':
     resolution: {integrity: sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.35.0':
     resolution: {integrity: sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.35.0':
     resolution: {integrity: sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.35.0':
     resolution: {integrity: sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.35.0':
     resolution: {integrity: sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.35.0':
     resolution: {integrity: sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.35.0':
     resolution: {integrity: sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.35.0':
     resolution: {integrity: sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==}
@@ -6078,6 +6042,12 @@ snapshots:
       '@prezly/uploads': 0.2.1
       query-string: 6.14.1
 
+  '@prezly/sdk@26.5.0':
+    dependencies:
+      '@prezly/progress-promise': 2.0.1
+      '@prezly/uploads': 0.2.1
+      query-string: 6.14.1
+
   '@prezly/story-content-format@0.70.0':
     dependencies:
       '@prezly/content-format': 0.70.1
@@ -6090,9 +6060,9 @@ snapshots:
       '@prezly/uploads': 0.2.1
       is-plain-object: 5.0.0
 
-  '@prezly/theme-kit-core@10.8.0(@prezly/sdk@23.17.0)':
+  '@prezly/theme-kit-core@10.8.0(@prezly/sdk@26.5.0)':
     dependencies:
-      '@prezly/sdk': 23.17.0
+      '@prezly/sdk': 26.5.0
       '@prezly/theme-kit-intl': 10.8.0
       '@prezly/uploadcare': 2.4.4
       '@technically/is-not-undefined': 1.0.0
@@ -6104,10 +6074,10 @@ snapshots:
     dependencies:
       '@technically/is-not-undefined': 1.0.0
 
-  '@prezly/theme-kit-nextjs@10.8.0(@playwright/test@1.57.0)(@prezly/sdk@23.17.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+  '@prezly/theme-kit-nextjs@10.8.0(@playwright/test@1.57.0)(@prezly/sdk@26.5.0)(next@15.5.12(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.85.1))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@prezly/sdk': 23.17.0
-      '@prezly/theme-kit-core': 10.8.0(@prezly/sdk@23.17.0)
+      '@prezly/sdk': 26.5.0
+      '@prezly/theme-kit-core': 10.8.0(@prezly/sdk@26.5.0)
       '@prezly/theme-kit-intl': 10.8.0
       '@prezly/theme-kit-react': 10.8.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@technically/is-not-undefined': 1.0.0

--- a/src/adapters/server/app.ts
+++ b/src/adapters/server/app.ts
@@ -22,6 +22,14 @@ export const { useApp: app } = AppHelperAdapter.connect({
             return contentDelivery.allStories(params, { include: ['thumbnail_image'] });
         }
 
+        async function policies() {
+            const { uuid } = await contentDelivery.newsroom();
+            const { policies: result } = await client.newsrooms.get(uuid, {
+                include: ['policies'],
+            });
+            return result;
+        }
+
         return {
             ...contentDelivery,
             client,
@@ -30,6 +38,7 @@ export const { useApp: app } = AppHelperAdapter.connect({
             stories,
             allStories,
             themeSettings,
+            policies,
             dateFormat: () => contentDelivery.newsroom().then((newsroom) => newsroom.date_format),
             timeFormat: () => contentDelivery.newsroom().then((newsroom) => newsroom.time_format),
         };


### PR DESCRIPTION
## Summary
- Public story page (`/[slug]`) issues a `308 Permanent Redirect` to `story.seo_settings.canonical_url` when **all** of:
  - newsroom has `redirect_to_canonical_url=true`
  - story has `seo_settings.canonical_url` set
  - story `visibility === 'public'` (private/confidential/embargoed stories are intentionally direct-shared, so they still render)
- Backed by prezly/prezly#18719.
- Bumps `@prezly/sdk` 23.17.0 → 26.5.0 — the first SDK version that exposes the new `Newsroom.redirect_to_canonical_url` field.
- In SDK 26.x, `policies` moved off the base `Newsroom` type into `ExtraFields`, so a small `app().policies()` helper fetches them via `client.newsrooms.get(uuid, { include: ['policies'] })`; the privacy- and cookie-policy pages were updated to use it.

## Test plan — all verified locally

| Case | Expected | Actual |
|---|---|---|
| Public story + flag + canonical | 308 → canonical | ✅ 308 |
| Private story + flag + canonical | 200 (render) | ✅ 200 |
| Privacy / cookie policy pages | 200 (render) | ✅ 200 |
| Preview route `/s/<uuid>?preview` | 200 (render) | ✅ 200 |
| Secret route `/s/<uuid>` | 200 (render) | ✅ 200 |

Typecheck (`pnpm tsc --noEmit`) is clean.