### PR TITLE
Fix story slugs starting with "api" returning 500

### DIFF
--- a/app/[localeCode]/layout.tsx
+++ b/app/[localeCode]/layout.tsx
@@ -1,5 +1,6 @@
 import { Locale, Newsrooms } from '@prezly/theme-kit-nextjs';
 import type { Viewport } from 'next';
+import { notFound } from 'next/navigation';
 import type { ReactNode } from 'react';
 
 import { ThemeSettingsProvider } from '@/adapters/client';
@@ -54,6 +55,12 @@ export async function generateViewport(): Promise<Viewport> {
 
 export async function generateMetadata(props: Props) {
     const params = await props.params;
+
+    // Guard against an unrecognized locale segment reaching this route (e.g. a
+    // path that bypassed the i18n middleware). `Locale.from` throws on invalid
+    // input, which would surface as a 500 — a 404 is the correct response here.
+    if (!Locale.isValid(params.localeCode)) notFound();
+
     const newsroom = await app().newsroom();
 
     const faviconUrl = Newsrooms.getFaviconUrl(newsroom, 180);
@@ -76,6 +83,9 @@ export default async function MainLayout(props: Props) {
     const params = await props.params;
 
     const { children } = props;
+
+    // See note in `generateMetadata`: 404 rather than 500 on an invalid locale.
+    if (!Locale.isValid(params.localeCode)) notFound();
 
     const { code: localeCode, isoCode, direction } = Locale.from(params.localeCode);
     const { isTrackingEnabled } = analytics();

--- a/middleware.ts
+++ b/middleware.ts
@@ -62,8 +62,13 @@ export const config = {
          * - robots.txt
          * - sitemap.xml
          * - favicon.ico
+         *
+         * Note: `api` is anchored with `(?:/|$)` so that only the `/api` segment
+         * is excluded — without it, story slugs that merely start with "api"
+         * (e.g. `/apidya-...`) would bypass the middleware and skip locale
+         * rewriting, causing the slug to be treated as a locale code (500).
          */
-        '/((?!api|_next/static|_next/image|favicon\\.ico$|sitemap\\.xml$|robots\\.txt$).*)',
+        '/((?!api(?:/|$)|_next/static|_next/image|favicon\\.ico$|sitemap\\.xml$|robots\\.txt$).*)',
     ],
 };
 


### PR DESCRIPTION
## Problem

Story slugs starting with `api` (e.g. `/apidya-special-launch-date-set`) returned **HTTP 500** for all visitors and crawlers, on **every newsroom**. Reported via Sentry as `THEMES-NEXTJS-42M` (697k occurrences / 23k users).

## Root cause

The i18n middleware matcher's negative lookahead excluded any path *starting with* `api`, not just `/api/*` route handlers — the `api` token was unanchored:

```
'/((?!api|_next/static|_next/image|favicon\.ico$|sitemap\.xml$|robots\.txt$).*)'
```

So `/apidya-...` bypassed the middleware entirely → no locale rewrite → the raw slug reached `app/[localeCode]/layout.tsx` as the locale segment → `Locale.from('apidya-…')` threw → uncaught → 500. (The `<link>`/`Event captured as promise rejection` entries in Sentry were downstream/injected-extension noise; the real failure was the RSC render error whose message production strips.)

This is deterministic and slug-specific: only slugs beginning with `api` (a common prefix) were affected.

## Fix

1. **`middleware.ts`** — anchor the exclusion to a path-segment boundary so only the `/api` segment is excluded:
   ```
   api  →  api(?:/|$)
   ```
2. **`app/[localeCode]/layout.tsx`** — defense-in-depth: `generateMetadata` and `MainLayout` now `notFound()` (404) on an unrecognized locale segment instead of letting `Locale.from()` throw a 500.

## Verification

Reproduced and verified locally against the affected newsroom:

| Path | Before | After |
|---|---|---|
| `/apidya-special-launch-date-set` | 500 | **200** (story renders) |
| `/apixyz-does-not-exist` | 500 | **404** (correct not-found) |
| `/api/stories`, `/api/galleries` (API routes) | excluded | **still excluded** |
| `/zebra-does-not-exist` | 404 | 404 (unchanged) |

The layout guard was independently confirmed by temporarily reinstating the buggy matcher: apidya returned **404 instead of 500**, then the fix was restored. `tsc --noEmit` passes.

Fixes THEMES-NEXTJS-42M