### PR TITLE
[DEV-23450] Acer Inc. > OneTrust Cookie Consent implementation to Pre…

### DIFF
--- a/src/modules/CookieConsent/components/OneTrustCookie/OneTrustManager.ts
+++ b/src/modules/CookieConsent/components/OneTrustCookie/OneTrustManager.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useCookieConsent } from '../../CookieConsentContext';
 import { ConsentCategory } from '../../types';
@@ -18,10 +18,10 @@ interface Props {
  */
 export function OneTrustManager({ category, isPreview }: Props) {
     const { registerUpdatePreferencesCallback, setConsent } = useCookieConsent();
+    const isOneTrustLoaded = useRef(false);
 
     useEffect(() => {
         function handleConsentChange() {
-            console.log('consent changed?');
             const categories: ConsentCategory[] = [];
 
             if (getOnetrustCookieConsentStatus(ONETRUST_NECESSARY_COOKIES_CATEGORY)) {
@@ -45,8 +45,17 @@ export function OneTrustManager({ category, isPreview }: Props) {
                 return;
             }
 
+            // OneTrust may call OptanonWrapper more than once while it is loading.
+            // We only need to connect our callbacks once because running this block again
+            // can make the banner render again and duplicate OneTrust events in GTM.
+            if (isOneTrustLoaded.current) {
+                return;
+            }
+
+            isOneTrustLoaded.current = true;
+            document.body.removeEventListener(ONETRUST_INTEGRATION_EVENT, onOneTrustLoaded);
+
             oneTrust.OnConsentChanged(handleConsentChange);
-            oneTrust.Init();
             if (isPreview) {
                 oneTrust.AllowAll();
                 setConsent({
@@ -57,12 +66,10 @@ export function OneTrustManager({ category, isPreview }: Props) {
                     ],
                 });
             } else {
-                oneTrust.LoadBanner();
+                handleConsentChange();
             }
 
-            registerUpdatePreferencesCallback(oneTrust.ToggleInfoDisplay);
-
-            document.body.removeEventListener(ONETRUST_INTEGRATION_EVENT, onOneTrustLoaded);
+            registerUpdatePreferencesCallback(() => oneTrust.ToggleInfoDisplay());
         }
 
         if (window.OneTrust) {


### PR DESCRIPTION
## Summary

Fixes duplicate OneTrust initialization in affected Next.js newsroom themes.

OneTrust can call `OptanonWrapper` more than once while the SDK is loading. Our integration handled every callback as a fresh load, which could cause the cookie banner to render again and duplicate OneTrust events in GTM, such as:

- `OneTrustLoaded`
- `OptanonLoaded`
- `OneTrustGroupsUpdated`

## Changes

- Added a guard so the Prezly OneTrust integration setup only runs once per page load
- Removed manual `OneTrust.Init()` and `OneTrust.LoadBanner()` calls
- Kept the initial consent state sync via `handleConsentChange()`
- Wrapped `OneTrust.ToggleInfoDisplay()` in a callback to preserve the correct method context
- Added a short code comment explaining why duplicate setup is avoided

## Why

When OneTrust is loaded through the native Prezly integration, the SDK may trigger `OptanonWrapper` multiple times. Re-running our setup on every callback caused repeated banner initialization and repeated GTM dataLayer events.

The fix lets OneTrust own its own initialization lifecycle while Prezly only connects its callbacks once.

## Testing

- Verified the Bea theme locally with the native OneTrust integration enabled
- Confirmed GTM preview no longer shows OneTrust events looping repeatedly
- Confirmed the source still includes the expected OneTrust script
- Confirmed local consent persistence needs a matching test domain because Acer’s OneTrust config is domain-specific

## GTM Preview
<img width="1893" height="733" alt="Screenshot 2026-06-22 at 12 11 24" src="https://github.com/user-attachments/assets/f24df7aa-d2c4-4406-bca6-a6b6c27c56a1" />

## Test OneTrust cookie banner appears in the newsroom
<img width="1227" height="895" alt="Screenshot 2026-06-22 at 12 12 19" src="https://github.com/user-attachments/assets/bc2048bb-ffab-4a4d-a04e-ac420e28c32b" />


