### PR TITLE
[DEV-23304] Fix galleries spacing

### DIFF
--- a/src/components/ContentRenderer/components/Gallery.module.scss
+++ b/src/components/ContentRenderer/components/Gallery.module.scss
@@ -1,6 +1,7 @@
 .chunks {
     display: flex;
     flex-direction: column;
+    margin: $spacing-6 0;
 }
 
 .chunk :global(.prezly-slate-gallery) {


### PR DESCRIPTION
Fixed spacing around galleries rendered inside content chunks.

The chunk loading update accidentally removed the default gallery spacing. This restores the expected `40px` vertical spacing while keeping the inner gallery margins reset to avoid double spacing.