### PR TITLE
[dev-23447] Make site name the homepage h1 instead of "Latest stories"

### DIFF
--- a/src/components/PageTitle/PageTitle.tsx
+++ b/src/components/PageTitle/PageTitle.tsx
@@ -7,12 +7,13 @@ interface Props {
     title: string;
     subtitle?: ReactNode;
     className?: string;
+    as?: 'h1' | 'h2';
 }
 
-export function PageTitle({ title, subtitle, className }: Props) {
+export function PageTitle({ title, subtitle, className, as: Heading = 'h1' }: Props) {
     return (
         <div className={classNames(styles.container, className)}>
-            <h1 className={styles.title}>{title}</h1>
+            <Heading className={styles.title}>{title}</Heading>
             {subtitle && <p className={styles.subtitle}>{subtitle}</p>}
         </div>
     );

--- a/src/modules/Header/ui/Header.module.scss
+++ b/src/modules/Header/ui/Header.module.scss
@@ -104,6 +104,7 @@ $header-height: 88px;
 }
 
 .title {
+    margin: 0;
     font-size: 1.75rem;
     line-height: 2.5rem;
     text-transform: uppercase;
@@ -111,6 +112,10 @@ $header-height: 88px;
 
     @include not-desktop {
         font-size: 1.25rem;
+    }
+
+    &.hidden {
+        @include sr-only;
     }
 }
 

--- a/src/modules/Header/ui/Header.tsx
+++ b/src/modules/Header/ui/Header.tsx
@@ -219,8 +219,10 @@ export function Header({
                                     [styles.withoutLogo]: !logo,
                                 })}
                             >
-                                {!logo && <div className={styles.title}>{newsroomName}</div>}
-                                {logo && <Logo alt={newsroomName} image={logo} size={logoSize} />}
+                                <h1 className={classNames(styles.title, { [styles.hidden]: logo })}>
+                                    {newsroomName}
+                                </h1>
+                                {logo && <Logo alt="" image={logo} size={logoSize} />}
                             </Link>
                         )}
 

--- a/src/modules/InfiniteStories/StoriesList.tsx
+++ b/src/modules/InfiniteStories/StoriesList.tsx
@@ -194,6 +194,7 @@ export function StoriesList({
             )}
             {withPageTitle && (
                 <PageTitle
+                    as="h2"
                     className={classNames(styles.pageTitle, {
                         // We want to hide the page title for regular users, but keep it
                         // for the screen readers.


### PR DESCRIPTION
## Problem

[DEV-23447](https://linear.app/prezly/issue/DEV-23447/bea-h1-bug)

On the BEA homepage the primary `<h1>` was the literal phrase **"Latest stories"**, and the newsroom/site name was never an `<h1>` — it was only a `<div>`, and only rendered when no logo was set. Customers (and the reporter) expect the homepage heading to be the **site name**, as it was in Lena.

## Fix (matches Lena)

Looked at how `theme-nextjs-lena` handles this and mirrored it:

- **`Header.tsx`** — the newsroom name is now always rendered as the page `<h1>` inside the logo link. When a logo exists, the h1 gets a `hidden` (sr-only) modifier and the logo uses `alt=""` (presentational, since the h1 carries the text). When there's no logo, the name shows visibly as before.
- **`Header.module.scss`** — added `.title.hidden { @include sr-only; }` and a `margin: 0` reset (it's an h1 now).
- **`PageTitle.tsx`** — added an optional `as` prop (default `'h1'`) so it stays h1 on Category/Tag/Gallery/Search pages.
- **`StoriesList.tsx`** — the "Latest stories" `PageTitle` now renders as `as="h2"` — a section heading under the site-name h1, not the page's primary heading. Its existing show/hide-by-featured-categories logic is untouched.

## Result

- Homepage `<h1>` = the **site name** (visible when no logo; sr-only behind the logo, so still present for SEO and screen readers).
- "Latest stories" is demoted to an `<h2>` section heading.
- No visible layout change for sites with a logo.

## Notes

- Story/category pages now carry two h1s (header site-name + story title / category name). This is intentional parity with Lena, which does the same.

## Testing

- `tsc --noEmit` passes
- `biome check` passes
