### PR TITLE
ci: allow manual workflow_dispatch for deploy

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  # Allows manually re-running the deploy from the Actions tab, e.g. when a
+  # merge-to-main push event fails to trigger CI (GitHub event-delivery miss).
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Why

When #1456 (DEV-23447) was merged, GitHub never created a CI run for the merge commit — no check-suite, no `build-and-push` run — so the image was never built/pushed to ECR and the fix didn't deploy. The `build-and-push` workflow only triggers on `push: main`, and there's no way to re-fire it without another push (and `main` is protected).

## What

Adds a `workflow_dispatch:` trigger to `build-and-push.yml` so the deploy can be re-run manually from the **Actions** tab whenever a merge push fails to trigger CI.

## Bonus

Merging this PR also produces a fresh `push: main` event, which should re-fire the deploy and finally ship the DEV-23447 h1 fix. If that push somehow gets dropped again, the new manual trigger is the fallback.