### PR TITLE
Localize market dropdown current-site name to the viewing locale

### DIFF
--- a/src/modules/Header/Languages.tsx
+++ b/src/modules/Header/Languages.tsx
@@ -50,15 +50,22 @@ export async function Languages({ localeCode, memberNewsrooms }: Props) {
     // Skip inactive newsrooms — they aren't live, so linking to them is a dead end.
     const peers: Peer[] = candidates.filter((peer) => Newsroom.isActive(peer)).map(toPeer);
 
+    // Use the newsroom name translated to the current locale (company_information.name),
+    // not the default display_name — e.g. "Belgium" on the English site, "België" in Dutch.
+    const currentNewsroomName =
+        languages.find((lang) => lang.code === localeCode)?.company_information.name ||
+        newsroom.display_name ||
+        newsroom.name;
+
     // Brand prefix shared across every newsroom in the hub (current + peers), stripped
     // from each label so country names read cleanly (e.g. "Acme UK" -> "UK").
     const sharedPrefix = computeSharedPrefix([
-        newsroom.display_name || newsroom.name,
+        currentNewsroomName,
         ...peers.map((peer) => peer.name),
     ]);
 
     const currentMarket: Market = {
-        countryName: stripPrefix(newsroom.display_name || newsroom.name, sharedPrefix),
+        countryName: stripPrefix(currentNewsroomName, sharedPrefix),
         newsroomUuid: newsroom.uuid,
         isCurrent: true,
         languages: languages


### PR DESCRIPTION
Follow-up to #1458.

## Problem
In the market dropdown, the current market's label used `newsroom.display_name` — the **default-locale** newsroom name. So on the English version of a site it showed the default name (e.g. "België") instead of the translated one ("Belgium").

## Fix
Use the current locale's `company_information.name` (the same per-locale newsroom name the header uses for the site title via `language.company_information`), falling back to `display_name`/`name`. This name also feeds the shared brand-prefix stripping, so the localized country label comes out clean (e.g. "Belgium" / "België").

```ts
const currentNewsroomName =
    languages.find((lang) => lang.code === localeCode)?.company_information.name ||
    newsroom.display_name ||
    newsroom.name;
```

## Known limitation
**Peer** market names still use their default `display_name` — the hub member/sibling data (`newsroomHub.list` / `newsroom.hub`) doesn't carry per-locale names, so localizing peers would require a separate language fetch per peer. Out of scope here; happy to follow up if we want peers localized too.

## Verification
- `tsc --noEmit` passes.
- Note: couldn't show a visual diff on the test hub since it only has one culture (English); the change mirrors the established `Header.tsx` pattern (`information.name || newsroom.display_name`).