### PR TITLE
[DEV-23586] Fix - dropdown zindex and search box text color

### DIFF
--- a/src/components/Dropdown/Dropdown.module.scss
+++ b/src/components/Dropdown/Dropdown.module.scss
@@ -14,6 +14,7 @@
     padding: $spacing-1;
     background: var(--prezly-background-color-secondary);
     border: 1px solid var(--prezly-border-color);
+    z-index: 10;
 
     @include mobile-only {
         max-width: 280px;
@@ -67,11 +68,15 @@
 }
 
 .transition {
-    transition: opacity 0.2s ease, transform 0.2s ease;
+    transition:
+        opacity 0.2s ease,
+        transform 0.2s ease;
 
     &.withMobileDisplay {
         @include mobile-only {
-            transition: opacity 0.2s ease, max-height 0.2s ease;
+            transition:
+                opacity 0.2s ease,
+                max-height 0.2s ease;
         }
     }
 }

--- a/src/modules/Header/ui/SearchWidget/SearchWidget.module.scss
+++ b/src/modules/Header/ui/SearchWidget/SearchWidget.module.scss
@@ -1,6 +1,6 @@
 .modal {
     padding: 0 !important;
-    background: var(--prezly-background-color);
+    background: var(--prezly-background-color) !important;
 
     @include mobile-only {
         margin: 0 !important;
@@ -19,7 +19,7 @@
 }
 
 .backdrop {
-    backdrop-filter: blur(3px);         /* main blur */
+    backdrop-filter: blur(3px); /* main blur */
     -webkit-backdrop-filter: blur(3px); /* Safari support */
 
     @include mobile-only {


### PR DESCRIPTION
- Fixed the search facet dropdown z-index so it no longer appears behind the category bar.
- Fixed the search widget modal background so it correctly uses the configured background color.

<img width="1199" height="864" alt="image" src="https://github.com/user-attachments/assets/5d02b9fd-4761-4fab-a2d9-09082145f7c7" />
<img width="1628" height="1090" alt="94984" src="https://github.com/user-attachments/assets/5725db1f-c454-477d-ae8f-38cbac50aa4a" />
