### PR TITLE
Handle tenant API auth failures gracefully and drop Server Actions

### DIFF
--- a/app/api/stories/[uuid]/pdf/route.ts
+++ b/app/api/stories/[uuid]/pdf/route.ts
@@ -1,0 +1,35 @@
+import { routing } from '@prezly/sdk';
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { environment } from '@/adapters/server';
+
+const PREZLY_API_URL = 'https://api.prezly.com';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface Props {
+    params: Promise<{ uuid: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: Props) {
+    const { uuid } = await params;
+
+    if (!UUID_PATTERN.test(uuid)) {
+        return new NextResponse('Bad Request', { status: 400 });
+    }
+
+    const env = environment(request.headers);
+
+    const { PREZLY_ACCESS_TOKEN, PREZLY_API_BASEURL = PREZLY_API_URL } = env;
+    const STORIES_ENDPOINT = `${PREZLY_API_BASEURL}${routing.storiesUrl}`;
+
+    const response = await fetch(`${STORIES_ENDPOINT}/${uuid}`, {
+        headers: {
+            Authorization: `Bearer ${PREZLY_ACCESS_TOKEN}`,
+            Accept: 'application/pdf',
+        },
+        redirect: 'manual',
+    });
+
+    return NextResponse.json({ url: response.headers.get('location') });
+}

--- a/app/api/stories/[uuid]/pdf/route.ts
+++ b/app/api/stories/[uuid]/pdf/route.ts
@@ -1,8 +1,10 @@
 import { routing } from '@prezly/sdk';
 import { type NextRequest, NextResponse } from 'next/server';
 
-import { environment } from '@/adapters/server';
+import { environment, logApiAuthFailure } from '@/adapters/server';
 
+// Default when the `X-Prezly-Env` tenant config does not override it via
+// `PREZLY_API_BASEURL` (same convention as the SDK adapter).
 const PREZLY_API_URL = 'https://api.prezly.com';
 
 const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -31,5 +33,33 @@ export async function GET(request: NextRequest, { params }: Props) {
         redirect: 'manual',
     });
 
-    return NextResponse.json({ url: response.headers.get('location') });
+    if (response.status === 401 || response.status === 403) {
+        logApiAuthFailure(response.status, request.headers);
+    }
+
+    const url = parsePdfUrl(response.headers.get('location'));
+
+    if (!url) {
+        // On success the API responds with a redirect (3xx + Location) to the
+        // rendered PDF. Anything else is an upstream failure: pass a missing
+        // story through as 404; everything else (including auth failures,
+        // which are a tenant configuration problem, not the visitor's) is a
+        // bad gateway.
+        return new NextResponse(null, { status: response.status === 404 ? 404 : 502 });
+    }
+
+    return NextResponse.json({ url });
+}
+
+function parsePdfUrl(location: string | null): string | null {
+    if (!location) {
+        return null;
+    }
+
+    try {
+        const url = new URL(location);
+        return url.protocol === 'https:' ? url.toString() : null;
+    } catch {
+        return null;
+    }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,8 +1,8 @@
 import { Locale } from '@prezly/theme-kit-nextjs';
 import { IntlMiddleware } from '@prezly/theme-kit-nextjs/middleware';
-import type { NextRequest } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 
-import { configureAppRouter, initPrezlyClient } from '@/adapters/server';
+import { configureAppRouter, initPrezlyClient, isApiAuthError } from '@/adapters/server';
 
 function parseNewsroomLocalesFromHeaders(headers: Headers): Locale.Code[] | undefined {
     const header = headers.get('X-Newsroom-Locales');
@@ -39,9 +39,24 @@ async function retrieveNewsroomLocalesFromApi(headers: Headers) {
 }
 
 export async function middleware(request: NextRequest) {
-    const locales =
-        parseNewsroomLocalesFromHeaders(request.headers) ??
-        (await retrieveNewsroomLocalesFromApi(request.headers));
+    let locales: Locale.Code[];
+
+    try {
+        locales =
+            parseNewsroomLocalesFromHeaders(request.headers) ??
+            (await retrieveNewsroomLocalesFromApi(request.headers));
+    } catch (error) {
+        // A rejected tenant token means every upstream API call will fail — bail out
+        // before rendering starts. 503 (not 404) so search engines treat the outage
+        // as temporary instead of deindexing a site that is only misconfigured.
+        if (isApiAuthError(error)) {
+            return new NextResponse('Service Temporarily Unavailable', {
+                status: 503,
+                headers: { 'retry-after': '300' },
+            });
+        }
+        throw error;
+    }
 
     const [defaultLocale] = locales; // default is expected to always be the first in the list
 

--- a/next-logger.config.js
+++ b/next-logger.config.js
@@ -4,12 +4,18 @@ const pino = require('pino');
  * The Prezly SDK attaches the full API response headers (including a multi-KB
  * CSP policy) to every `ApiError` it throws. They carry no diagnostic signal
  * but multiply the size of every logged error, so strip them before the error
- * is serialized.
+ * is serialized. Scoped to HTTP-response-shaped errors (`status` + `headers`)
+ * so headers carried by unrelated error types are left untouched.
  */
 function serializeError(error) {
     const serialized = pino.stdSerializers.err(error);
 
-    if (serialized && typeof serialized === 'object' && 'headers' in serialized) {
+    if (
+        serialized &&
+        typeof serialized === 'object' &&
+        'headers' in serialized &&
+        'status' in serialized
+    ) {
         const { headers, ...rest } = serialized;
         return rest;
     }

--- a/next-logger.config.js
+++ b/next-logger.config.js
@@ -1,0 +1,28 @@
+const pino = require('pino');
+
+/**
+ * The Prezly SDK attaches the full API response headers (including a multi-KB
+ * CSP policy) to every `ApiError` it throws. They carry no diagnostic signal
+ * but multiply the size of every logged error, so strip them before the error
+ * is serialized.
+ */
+function serializeError(error) {
+    const serialized = pino.stdSerializers.err(error);
+
+    if (serialized && typeof serialized === 'object' && 'headers' in serialized) {
+        const { headers, ...rest } = serialized;
+        return rest;
+    }
+
+    return serialized;
+}
+
+const logger = (defaultConfig) =>
+    pino({
+        ...defaultConfig,
+        serializers: {
+            err: serializeError,
+        },
+    });
+
+module.exports = { logger };

--- a/src/adapters/server/api-error.ts
+++ b/src/adapters/server/api-error.ts
@@ -1,0 +1,86 @@
+import { environment } from './environment';
+
+/*
+ * Rejected tenant credentials (revoked or rotated newsroom token) surface as
+ * SDK `ApiError`s on every request, but the framework-logged error does not
+ * identify the tenant. The helpers here detect those errors and log them with
+ * the request host and newsroom UUID, so the broken tenant can be found from
+ * the logs.
+ */
+
+const LOG_THROTTLE_MS = 60_000;
+
+const lastLoggedAt = new Map<string, number>();
+
+/**
+ * Detected by shape rather than `instanceof ApiError` — multiple copies of
+ * `@prezly/sdk` can end up in the server bundle, each with its own class.
+ */
+export function isApiAuthError(error: unknown): error is Error & { status: number } {
+    return (
+        error instanceof Error &&
+        'status' in error &&
+        (error.status === 401 || error.status === 403)
+    );
+}
+
+/**
+ * Wraps a client object so that API auth failures thrown from any of its
+ * methods are logged with tenant identification (at most once per newsroom
+ * per minute). The error is rethrown untouched.
+ */
+export function reportApiAuthErrors<T extends object>(client: T, requestHeaders: Headers): T {
+    return new Proxy(client, {
+        get(target, property, receiver) {
+            const value = Reflect.get(target, property, receiver);
+
+            if (typeof value !== 'function') {
+                return value;
+            }
+
+            return (...args: unknown[]) => {
+                const result = Reflect.apply(value, target, args);
+
+                if (result instanceof Promise) {
+                    return result.catch((error: unknown) => {
+                        logApiAuthError(error, requestHeaders);
+                        throw error;
+                    });
+                }
+
+                return result;
+            };
+        },
+    });
+}
+
+function logApiAuthError(error: unknown, requestHeaders: Headers) {
+    if (!isApiAuthError(error)) {
+        return;
+    }
+
+    const host = requestHeaders.get('x-forwarded-host') ?? requestHeaders.get('host') ?? 'unknown';
+    const newsroom = identifyNewsroom(requestHeaders) ?? 'unknown';
+
+    const key = `${newsroom}:${error.status}`;
+    const now = Date.now();
+    const loggedAt = lastLoggedAt.get(key);
+
+    if (loggedAt !== undefined && now - loggedAt < LOG_THROTTLE_MS) {
+        return;
+    }
+    lastLoggedAt.set(key, now);
+
+    console.warn(
+        `Prezly API rejected the access token (${error.status}) for newsroom=${newsroom} host=${host}. ` +
+            'The token configured for this site is likely revoked or rotated.',
+    );
+}
+
+function identifyNewsroom(requestHeaders: Headers): string | undefined {
+    try {
+        return environment(requestHeaders).PREZLY_NEWSROOM_UUID;
+    } catch {
+        return undefined;
+    }
+}

--- a/src/adapters/server/api-error.ts
+++ b/src/adapters/server/api-error.ts
@@ -9,6 +9,7 @@ import { environment } from './environment';
  */
 
 const LOG_THROTTLE_MS = 60_000;
+const MAX_TRACKED_TENANTS = 1_000;
 
 const lastLoggedAt = new Map<string, number>();
 
@@ -43,7 +44,9 @@ export function reportApiAuthErrors<T extends object>(client: T, requestHeaders:
 
                 if (result instanceof Promise) {
                     return result.catch((error: unknown) => {
-                        logApiAuthError(error, requestHeaders);
+                        if (isApiAuthError(error)) {
+                            logApiAuthFailure(error.status, requestHeaders);
+                        }
                         throw error;
                     });
                 }
@@ -54,27 +57,52 @@ export function reportApiAuthErrors<T extends object>(client: T, requestHeaders:
     });
 }
 
-function logApiAuthError(error: unknown, requestHeaders: Headers) {
-    if (!isApiAuthError(error)) {
-        return;
-    }
-
+/**
+ * Logs an API auth failure with tenant identification, at most once per
+ * newsroom per minute.
+ */
+export function logApiAuthFailure(status: number, requestHeaders: Headers) {
     const host = requestHeaders.get('x-forwarded-host') ?? requestHeaders.get('host') ?? 'unknown';
     const newsroom = identifyNewsroom(requestHeaders) ?? 'unknown';
 
-    const key = `${newsroom}:${error.status}`;
-    const now = Date.now();
+    if (!shouldLog(`${newsroom}:${status}`, Date.now())) {
+        return;
+    }
+
+    console.warn(
+        `Prezly API rejected the access token (${status}) for newsroom=${newsroom} host=${host}. ` +
+            'The token configured for this site is likely revoked or rotated.',
+    );
+}
+
+function shouldLog(key: string, now: number): boolean {
     const loggedAt = lastLoggedAt.get(key);
 
     if (loggedAt !== undefined && now - loggedAt < LOG_THROTTLE_MS) {
-        return;
+        return false;
     }
+
+    if (lastLoggedAt.size >= MAX_TRACKED_TENANTS) {
+        for (const [trackedKey, trackedAt] of lastLoggedAt) {
+            if (now - trackedAt >= LOG_THROTTLE_MS) {
+                lastLoggedAt.delete(trackedKey);
+            }
+        }
+        // If every tracked entry is still within the throttle window, drop the
+        // oldest one (Map iterates in insertion order) to keep the size bounded.
+        if (lastLoggedAt.size >= MAX_TRACKED_TENANTS) {
+            const oldest = lastLoggedAt.keys().next().value;
+            if (oldest !== undefined) {
+                lastLoggedAt.delete(oldest);
+            }
+        }
+    }
+
+    // Delete before set, so refreshed keys move to the back of the eviction order.
+    lastLoggedAt.delete(key);
     lastLoggedAt.set(key, now);
 
-    console.warn(
-        `Prezly API rejected the access token (${error.status}) for newsroom=${newsroom} host=${host}. ` +
-            'The token configured for this site is likely revoked or rotated.',
-    );
+    return true;
 }
 
 function identifyNewsroom(requestHeaders: Headers): string | undefined {

--- a/src/adapters/server/index.ts
+++ b/src/adapters/server/index.ts
@@ -1,4 +1,5 @@
 export * from './analytics';
+export * from './api-error';
 export * from './app';
 export * from './environment';
 export * from './intl';

--- a/src/adapters/server/prezly.ts
+++ b/src/adapters/server/prezly.ts
@@ -2,6 +2,7 @@ import { Story } from '@prezly/sdk';
 import { PrezlyAdapter } from '@prezly/theme-kit-nextjs/server';
 import { headers, type UnsafeUnwrappedHeaders } from 'next/headers';
 
+import { reportApiAuthErrors } from './api-error';
 import { environment } from './environment';
 
 // @ts-expect-error
@@ -49,5 +50,10 @@ export function initPrezlyClient(
         },
     );
 
-    return adapter.usePrezlyClient();
+    const { client, contentDelivery } = adapter.usePrezlyClient();
+
+    return {
+        client,
+        contentDelivery: reportApiAuthErrors(contentDelivery, requestHeaders),
+    };
 }

--- a/src/modules/Story/Share/utils/getStoryPdfUrl.ts
+++ b/src/modules/Story/Share/utils/getStoryPdfUrl.ts
@@ -1,5 +1,10 @@
 import type { Story } from '@prezly/sdk';
 
+/**
+ * Browser-side helper — resolves the story PDF export URL through this site's
+ * own `/api/stories/[uuid]/pdf` route. Must only be called from client code
+ * (the relative URL has no meaning during server rendering).
+ */
 export async function getStoryPdfUrl(uuid: Story['uuid']): Promise<string | null> {
     const response = await fetch(`/api/stories/${uuid}/pdf`);
 
@@ -7,7 +12,11 @@ export async function getStoryPdfUrl(uuid: Story['uuid']): Promise<string | null
         return null;
     }
 
-    const { url } = (await response.json()) as { url: string | null };
+    const data: unknown = await response.json().catch(() => null);
 
-    return url;
+    if (data && typeof data === 'object' && 'url' in data && typeof data.url === 'string') {
+        return data.url;
+    }
+
+    return null;
 }

--- a/src/modules/Story/Share/utils/getStoryPdfUrl.ts
+++ b/src/modules/Story/Share/utils/getStoryPdfUrl.ts
@@ -1,24 +1,13 @@
-'use server';
+import type { Story } from '@prezly/sdk';
 
-import { routing, type Story } from '@prezly/sdk';
-import { headers } from 'next/headers';
+export async function getStoryPdfUrl(uuid: Story['uuid']): Promise<string | null> {
+    const response = await fetch(`/api/stories/${uuid}/pdf`);
 
-import { environment } from '@/adapters/server';
+    if (!response.ok) {
+        return null;
+    }
 
-const PREZLY_API_URL = 'https://api.prezly.com';
+    const { url } = (await response.json()) as { url: string | null };
 
-export async function getStoryPdfUrl(uuid: Story['uuid']) {
-    const requestHeaders = await headers();
-    const env = environment(requestHeaders);
-
-    const { PREZLY_ACCESS_TOKEN, PREZLY_API_BASEURL = PREZLY_API_URL } = env;
-    const STORIES_ENDPOINT = `${PREZLY_API_BASEURL}${routing.storiesUrl}`;
-
-    return fetch(`${STORIES_ENDPOINT}/${uuid}`, {
-        headers: {
-            Authorization: `Bearer ${PREZLY_ACCESS_TOKEN}`,
-            Accept: 'application/pdf',
-        },
-        redirect: 'manual',
-    }).then((response) => response.headers.get('location'));
+    return url;
 }

--- a/src/modules/Story/Share/utils/htmlToText.ts
+++ b/src/modules/Story/Share/utils/htmlToText.ts
@@ -1,5 +1,3 @@
-'use server';
-
 import { convert } from 'html-to-text';
 
 export async function htmlToText(html: string) {


### PR DESCRIPTION
## Problem

Production pods (`theme-nextjs-bea`, `-preview`) log a flood of `API Error (401): Unauthorized` entries whenever a tenant's access token is revoked or rotated:

- every request for the affected newsroom crashes the RSC render into a 500,
- each error line is ~6.5KB (the SDK attaches the full API response headers, including the CSP policy),
- nothing in the logs identifies **which** newsroom/host is broken.

Separately, the `-reverse` pods log `Failed to find Server Action` warnings — stale browser tabs POSTing build-scoped action IDs after a redeploy.

## Changes

### Tenant auth failures (401/403)

- **`src/adapters/server/api-error.ts`** — wraps the content-delivery client so any 401/403 from the Prezly API logs a warning **with the request host and newsroom UUID**, throttled to once per newsroom per minute, then rethrows. Covers all `app()` calls, API routes, and the middleware.
- **`middleware.ts`** — when locale resolution hits an auth error, respond `503` + `retry-after: 300` before rendering starts. 503 (not 404) so search engines treat the outage as temporary. When the gateway supplies `X-Newsroom-Locales`, the middleware skips the API and render-path failures still surface as 500 with the branded error page — an RSC render cannot emit a custom status; the log spam was the actionable problem.

### Log noise

- **`next-logger.config.js`** — pino `err` serializer that strips the API response headers from serialized errors while keeping `status`, `payload`, `stack`, and `digest`. Picked up automatically by the existing `NODE_OPTIONS='-r next-logger'` in the Dockerfile. Error lines: ~6,500 → ~690 bytes.

### Server Actions eliminated

- **`app/api/stories/[uuid]/pdf/route.ts`** — replaces the `getStoryPdfUrl` Server Action with a stable-URL route handler (same logic, plus UUID validation → 400 on malformed input). The client util now fetches it.
- **`htmlToText`** — dropped `'use server'`; `html-to-text` is pure JS and runs in the browser inside the already-lazy "Copy text" chunk (First Load JS unchanged, story page 265 kB).
- The build's server-reference manifest is now empty — zero Server Actions remain, so the deploy-skew error class cannot recur.

## Verification

- `tsc`, `biome check`, and full `next build` all clean.
- Ran the production build locally with `next-logger` preloaded and a forged `X-Prezly-Env` carrying an invalid token:
  - middleware path → **503** with `retry-after: 300`;
  - render path → 500 + `Prezly API rejected the access token (401) for newsroom=… host=broken-tenant.example.com` logged once;
  - `GET /api/stories/<uuid>/pdf` → `{"url":null}` gracefully; malformed uuid → 400;
  - zero CSP header content in any log line.

## Follow-up (outside this repo)

The root cause is upstream: the routing layer keeps sending traffic (with a stale token) for a tenant the API rejects. Once deployed, the new warn logs identify exactly which newsroom/host it is; the durable fix is to stop routing revoked tenants at the gateway and make token rotation update the env store atomically.
