### PR TITLE
[dev-23729] Match masonry hero image proportions

### DIFF
--- a/src/components/StoryCards/HighlightedStoryCard.tsx
+++ b/src/components/StoryCards/HighlightedStoryCard.tsx
@@ -19,6 +19,7 @@ type Props = {
     fullWidth: boolean;
     newsroomLogo: UploadedImage | null;
     newsroomName: string;
+    preserveImageRatio: boolean;
     rounded: boolean;
     showDate: boolean;
     showSubtitle: boolean;
@@ -29,6 +30,7 @@ export function HighlightedStoryCard({
     fullWidth,
     newsroomLogo,
     newsroomName,
+    preserveImageRatio,
     rounded,
     showDate,
     showSubtitle,
@@ -111,6 +113,7 @@ export function HighlightedStoryCard({
             fallback={fallback}
             layout="horizontal"
             placeholder={{}}
+            preserveImageRatio={preserveImageRatio}
             publishedAt={story.published_at}
             showDate={showDate}
             showSubtitle={showSubtitle}

--- a/src/components/StoryCards/StoryCard.module.scss
+++ b/src/components/StoryCards/StoryCard.module.scss
@@ -156,6 +156,18 @@
     }
 }
 
+.hero.preserveImageRatio {
+    @include desktop-up {
+        .imageWrapper {
+            flex: 3;
+        }
+
+        .content {
+            flex: 2;
+        }
+    }
+}
+
 .boxed {
     @include border-radius-m;
 

--- a/src/components/StoryCards/StoryCard.tsx
+++ b/src/components/StoryCards/StoryCard.tsx
@@ -83,7 +83,7 @@ export function StoryCard({
                     isStatic={withStaticImage || preserveImageRatio}
                     placeholder={placeholder}
                     placeholderClassName={styles.placeholder}
-                    size={size}
+                    size={size === 'hero' && preserveImageRatio ? 'wide-hero' : size}
                     thumbnailImage={thumbnailImage}
                     title={titleAsString}
                 />

--- a/src/components/StoryCards/StoryCard.tsx
+++ b/src/components/StoryCards/StoryCard.tsx
@@ -19,6 +19,7 @@ type Props = {
     forceAspectRatio?: boolean;
     layout: 'horizontal' | 'vertical';
     placeholder: StoryImage.Props['placeholder'];
+    preserveImageRatio?: boolean;
     publishedAt: string | null;
     showDate: boolean;
     showSubtitle: boolean;
@@ -41,6 +42,7 @@ export function StoryCard({
     forceAspectRatio,
     layout,
     placeholder,
+    preserveImageRatio = false,
     publishedAt,
     showDate,
     showSubtitle,
@@ -68,8 +70,9 @@ export function StoryCard({
                 [styles.hero]: size === 'hero',
                 [styles.small]: size === 'small',
                 [styles.horizontal]: layout === 'horizontal',
+                [styles.preserveImageRatio]: preserveImageRatio,
                 [styles.vertical]: layout === 'vertical',
-                [styles.withStaticImage]: withStaticImage,
+                [styles.withStaticImage]: withStaticImage || preserveImageRatio,
             })}
         >
             <Link href={href} className={styles.imageWrapper} title={titleAsString}>
@@ -77,7 +80,7 @@ export function StoryCard({
                     className={styles.image}
                     fallback={fallback}
                     forceAspectRatio={forceAspectRatio ? 4 / 3 : undefined}
-                    isStatic={withStaticImage}
+                    isStatic={withStaticImage || preserveImageRatio}
                     placeholder={placeholder}
                     placeholderClassName={styles.placeholder}
                     size={size}

--- a/src/components/StoryCards/StoryCard.tsx
+++ b/src/components/StoryCards/StoryCard.tsx
@@ -57,6 +57,7 @@ export function StoryCard({
     withStaticImage = false,
 }: Props) {
     const hasCategories = translatedCategories.length > 0;
+    const isStaticImage = withStaticImage || preserveImageRatio;
     const HeadingTag = size === 'small' ? 'h3' : 'h2';
 
     const href = external
@@ -72,7 +73,7 @@ export function StoryCard({
                 [styles.horizontal]: layout === 'horizontal',
                 [styles.preserveImageRatio]: preserveImageRatio,
                 [styles.vertical]: layout === 'vertical',
-                [styles.withStaticImage]: withStaticImage || preserveImageRatio,
+                [styles.withStaticImage]: isStaticImage,
             })}
         >
             <Link href={href} className={styles.imageWrapper} title={titleAsString}>
@@ -80,7 +81,7 @@ export function StoryCard({
                     className={styles.image}
                     fallback={fallback}
                     forceAspectRatio={forceAspectRatio ? 4 / 3 : undefined}
-                    isStatic={withStaticImage || preserveImageRatio}
+                    isStatic={isStaticImage}
                     placeholder={placeholder}
                     placeholderClassName={styles.placeholder}
                     size={size === 'hero' && preserveImageRatio ? 'wide-hero' : size}

--- a/src/components/StoryImage/lib.ts
+++ b/src/components/StoryImage/lib.ts
@@ -1,7 +1,7 @@
 import type { Story } from '@prezly/sdk';
 import type { UploadcareImageDetails } from '@prezly/uploadcare-image/build/types';
 
-export type ImageSize = 'small' | 'medium' | 'big' | 'hero' | 'full-width' | 'tiny';
+export type ImageSize = 'small' | 'medium' | 'big' | 'hero' | 'wide-hero' | 'full-width' | 'tiny';
 
 export function getStoryThumbnail(
     thumbnailImage: Story.ExtraFields['thumbnail_image'],
@@ -29,6 +29,7 @@ function getPhoneImageSize(imageSize: ImageSize) {
     switch (imageSize) {
         case 'full-width':
         case 'hero':
+        case 'wide-hero':
             return '100w';
         default:
             return '95w';
@@ -39,6 +40,7 @@ function getTabletImageSize(imageSize: ImageSize) {
     switch (imageSize) {
         case 'full-width':
         case 'hero':
+        case 'wide-hero':
             return '100w';
         case 'small':
             return '200px';
@@ -51,6 +53,8 @@ function getDesktopImageSize(imageSize: ImageSize) {
     switch (imageSize) {
         case 'full-width':
             return '1200px';
+        case 'wide-hero':
+            return '690px';
         case 'medium':
             return '370px';
         case 'small':

--- a/src/modules/InfiniteStories/StoriesList.tsx
+++ b/src/modules/InfiniteStories/StoriesList.tsx
@@ -187,6 +187,7 @@ export function StoriesList({
                                 fullWidth={fullWidthFeaturedStory}
                                 newsroomName={newsroomName}
                                 newsroomLogo={newsroom?.newsroom_logo ?? null}
+                                preserveImageRatio={layout === 'masonry'}
                                 rounded={storyCardVariant === 'boxed'}
                                 showDate={showDate}
                                 showSubtitle={showSubtitle}


### PR DESCRIPTION
## What changed

- preserve the featured story image's natural aspect ratio when the story list uses masonry layout
- widen the desktop masonry hero to a 60/40 image-to-content split
- keep the existing grid hero and mobile/tablet stacking unchanged
- kept knowledge of layout `layout === 'masonry'` in the parent component where it already was.

## Why

The featured story wrapper was always forced to a 4:3 aspect ratio. Wider thumbnails, including 16:9 images, were therefore cropped even though masonry story cards preserve their source proportions.

## Impact

Masonry newsrooms show the complete featured thumbnail at desktop widths. Grid newsrooms and the full-width featured-story variant retain their current presentation.

Affects 334 live newsrooms.

## Validation

- `biome check` on the changed TypeScript files
- `tsc --noEmit --incremental`
- `git diff --check`

## Visual verification

### before
<img width="1554" height="1700" alt="CleanShot 2026-07-28 at 15 54 27@2x" src="https://github.com/user-attachments/assets/b3d48608-3029-440c-a818-0aa11203e628" />

### After
With masonry turned on:
<img width="2850" height="2046" alt="CleanShot 2026-07-28 at 15 54 43@2x" src="https://github.com/user-attachments/assets/bdeaf917-e34c-4f67-beea-c87b410f0a45" />
<img width="2092" height="2154" alt="CleanShot 2026-07-28 at 15 50 41@2x" src="https://github.com/user-attachments/assets/ca04fd25-cad1-46d2-b1ae-7acc51ec7a83" />

With Masonry turned off (ie Grid):
<img width="2078" height="2362" alt="CleanShot 2026-07-28 at 15 51 46@2x" src="https://github.com/user-attachments/assets/c1356cec-a9fd-4643-932b-d1a5b9112a4d" />



