### PR TITLE
Fix wrapped story images in newsroom

### DIFF
--- a/src/components/ContentRenderer/ContentRenderer.module.scss
+++ b/src/components/ContentRenderer/ContentRenderer.module.scss
@@ -1,4 +1,5 @@
 $avatar-size: 60px;
+$wrapped-image-width: 320px;
 
 // This class is attached to ContentRenderer so that we can
 // modify some global styles for components that are coming
@@ -178,6 +179,44 @@ $avatar-size: 60px;
             &__description {
                 color: var(--prezly-text-color-secondary);
             }
+        }
+    }
+}
+
+.wrappedImage {
+    @include tablet-up {
+        float: left;
+        clear: left;
+        position: static;
+        left: auto;
+        right: auto;
+        width: min(50%, $wrapped-image-width);
+        margin: 0 $spacing-6 $spacing-4 0 !important;
+        text-align: left;
+
+        :global {
+            .prezly-slate-image__link,
+            .prezly-slate-image-rollover,
+            .prezly-slate-image__media,
+            img,
+            video {
+                width: 100% !important;
+                max-width: 100%;
+            }
+
+            .prezly-slate-image__caption {
+                padding-right: 0;
+                padding-left: 0;
+                text-align: inherit;
+            }
+        }
+
+        &:global(.prezly-slate-image--align-right) {
+            float: right;
+            clear: right;
+            margin-right: 0 !important;
+            margin-left: $spacing-6 !important;
+            text-align: right;
         }
     }
 }

--- a/src/components/ContentRenderer/components/Image.tsx
+++ b/src/components/ContentRenderer/components/Image.tsx
@@ -8,13 +8,20 @@ import type { PropsWithChildren } from 'react';
 import { analytics } from '@/utils';
 import { CDN_URL } from '@/constants';
 
+import styles from '../ContentRenderer.module.scss';
+
 interface Props {
     node: ImageNode;
+}
+
+function isWrappedImageNode(node: ImageNode): boolean {
+    return 'wrap' in node && node.wrap === true;
 }
 
 export function Image({ node, children }: PropsWithChildren<Props>) {
     return (
         <Elements.Image
+            className={isWrappedImageNode(node) ? styles.wrappedImage : undefined}
             node={node}
             onDownload={(image) => {
                 analytics.track(DOWNLOAD.IMAGE, { id: image.uuid });

--- a/src/modules/Story/Story.tsx
+++ b/src/modules/Story/Story.tsx
@@ -143,7 +143,11 @@ function pullHeaderImageNode(
     const { children } = documentNode;
     const [firstNode] = children;
 
-    if (ImageNode.isImageNode(firstNode) && withHeaderImage === 'above') {
+    if (
+        ImageNode.isImageNode(firstNode) &&
+        withHeaderImage === 'above' &&
+        !('wrap' in firstNode && firstNode.wrap === true)
+    ) {
         return [
             { ...documentNode, children: [firstNode] },
             { ...documentNode, children: children.slice(1) },


### PR DESCRIPTION
## Summary
This PR fixes wrapped images in Bea newsroom stories.

Previously, when a story started with a wrapped image, the theme treated that image like a header image instead of keeping it inside the article. Because of that, the text could not flow around the image as expected.

Now wrapped images stay in the article body, and the article text wraps around them properly.