### PR TITLE
DEV-20589: Add WebSite JSON-LD structured data

### DIFF
--- a/app/[localeCode]/(index)/page.tsx
+++ b/app/[localeCode]/(index)/page.tsx
@@ -5,8 +5,14 @@ import dynamic from 'next/dynamic';
 import { app, generatePageMetadata, routing } from '@/adapters/server';
 import { Contacts } from '@/modules/Contacts';
 import { FeaturedCategories } from '@/modules/FeaturedCategories';
+import { JsonLd } from '@/modules/Head';
 import type { NewsroomWithHubLayout } from '@/types';
-import { getStoryListPageSize, parseId, parsePreviewSearchParams } from '@/utils';
+import {
+    buildWebsiteSchema,
+    getStoryListPageSize,
+    parseId,
+    parsePreviewSearchParams,
+} from '@/utils';
 
 interface Props {
     params: Promise<{
@@ -56,8 +62,13 @@ const HubStories = dynamic(
 export default async function StoriesIndexPage(props: Props) {
     const searchParams = await props.searchParams;
     const params = await props.params;
-    const newsroom = (await app().newsroom()) as NewsroomWithHubLayout;
-    const settings = await app().themeSettings();
+    const [newsroomRaw, defaultLocale, companyInformation, settings] = await Promise.all([
+        app().newsroom(),
+        app().defaultLocale(),
+        app().companyInformation(params.localeCode),
+        app().themeSettings(),
+    ]);
+    const newsroom = newsroomRaw as NewsroomWithHubLayout;
     const themeSettings = parsePreviewSearchParams(searchParams, settings);
 
     // In market_dropdown mode the hub root behaves like a single site:
@@ -66,8 +77,15 @@ export default async function StoriesIndexPage(props: Props) {
     // via the MarketsPanel in the header.
     const isHubWithTiles = newsroom.is_hub && newsroom.hub_layout !== 'market_dropdown';
 
+    // Google only treats the domain/subdomain root as the site homepage for
+    // site-name WebSite structured data — not locale-prefixed paths like /fr.
+    const isSiteHomepage = params.localeCode === defaultLocale;
+
     return (
         <>
+            {isSiteHomepage && (
+                <JsonLd schema={buildWebsiteSchema({ newsroom, companyInformation })} />
+            )}
             {isHubWithTiles ? (
                 <HubStories
                     layout={themeSettings.layout}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -25,6 +25,7 @@ export { slugifyHeading } from './slugifyHeading';
 export {
     buildNewsArticleSchema,
     buildOrganizationSchema,
+    buildWebsiteSchema,
     serializeJsonLd,
     type JsonLdSchema,
 } from './structuredData';

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -52,6 +52,43 @@ export function buildOrganizationSchema(params: {
     };
 }
 
+/**
+ * Preferred signal for Google Search site names.
+ * @see https://developers.google.com/search/docs/appearance/site-names
+ *
+ * Must be rendered on the site homepage (domain/subdomain root), not on
+ * every page. Includes the lowercase hostname as `alternateName` so Google
+ * has a fallback if it rejects the preferred brand name.
+ */
+export function buildWebsiteSchema({
+    newsroom,
+    companyInformation,
+}: {
+    newsroom: PublisherNewsroom;
+    companyInformation: PublisherCompanyInformation;
+}): JsonLdSchema {
+    const name = companyInformation.name || newsroom.name;
+    const hostname = getHostname(newsroom.url);
+    const alternateName =
+        hostname && hostname.toLowerCase() !== name.toLowerCase() ? hostname : undefined;
+
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name,
+        url: newsroom.url,
+        ...(alternateName && { alternateName }),
+    };
+}
+
+function getHostname(url: string): string | undefined {
+    try {
+        return new URL(url).hostname.toLowerCase();
+    } catch {
+        return undefined;
+    }
+}
+
 export function buildNewsArticleSchema({
     story,
     newsroom,


### PR DESCRIPTION
### Tickets

- https://linear.app/prezly/issue/DEV-20589/ubisoft-google-search-results-displaying-an-incorrect-site-label
- https://linear.app/prezly/issue/DEV-23759/lalique-httpspresslaliquecombrioni-unveils-mare-assoluto-google-search

### Summary

- Add `WebSite` JSON-LD structured data on the Bea homepage to provide Google’s preferred site-name signal.
- Build the schema from existing newsroom/company information (`name`, `url`), and include the lowercase hostname as `alternateName` fallback.
- Render it only on the default-locale homepage (domain/subdomain root), matching Google’s technical guidelines.

### Why

Google Search site names are automated. Without `WebSite` structured data, Google may infer an incorrect site label from weaker/external signals even when `og:site_name` and Organization JSON-LD are already correct.

This is relevant for cases like Lalique showing “Lalique North America” instead of “Lalique Group”, and similar Ubisoft reports.

Reference: [Google site names documentation](https://developers.google.com/search/docs/appearance/site-names)

### Test plan

- [ ] Confirm homepage HTML includes:

```html
<script type="application/ld+json">
{
  "@context": "https://schema.org",
  "@type": "WebSite",
  "name": "...",
  "url": "...",
  "alternateName": "..."
}
</script>
```

- [ ] Confirm `WebSite` JSON-LD is present on the default-locale homepage (`/`)
- [ ] Confirm it is **not** added on locale-prefixed homepages (e.g. `/fr`) or story pages
- [ ] Confirm existing `Organization` JSON-LD in layout still works
- [ ] Confirm existing `NewsArticle` JSON-LD on story pages still works
- [ ] Validate JSON-LD syntax with Schema Markup Validator
- [ ] After deploy, optionally request homepage indexing in Google Search Console
