### PR TITLE
DEV-23550: Remove the mask in story in-app previews

### DIFF
--- a/src/components/PreviewPageMask/PreviewPageMask.module.scss
+++ b/src/components/PreviewPageMask/PreviewPageMask.module.scss
@@ -1,6 +1,0 @@
-.mask {
-    position: fixed;
-    inset: 0;
-    background: transparent;
-    z-index: 9999;
-}

--- a/src/components/PreviewPageMask/PreviewPageMask.tsx
+++ b/src/components/PreviewPageMask/PreviewPageMask.tsx
@@ -4,6 +4,8 @@ import { useEffect } from 'react';
 
 import { useMaskParam } from '@/hooks';
 
+const CAPTURE_OPTIONS: AddEventListenerOptions = { capture: true };
+
 function getLinkFromEventTarget(target: EventTarget | null): HTMLAnchorElement | null {
     if (!(target instanceof Element)) {
         return null;
@@ -24,6 +26,11 @@ function preventLinkNavigation(event: MouseEvent) {
     event.preventDefault();
 }
 
+function preventFormNavigation(event: Event) {
+    event.preventDefault();
+    event.stopPropagation();
+}
+
 export function PreviewPageMask() {
     const mask = useMaskParam();
 
@@ -32,12 +39,14 @@ export function PreviewPageMask() {
             return;
         }
 
-        document.addEventListener('click', preventLinkNavigation, true);
-        document.addEventListener('auxclick', preventLinkNavigation, true);
+        document.addEventListener('click', preventLinkNavigation, CAPTURE_OPTIONS);
+        document.addEventListener('auxclick', preventLinkNavigation, CAPTURE_OPTIONS);
+        document.addEventListener('submit', preventFormNavigation, CAPTURE_OPTIONS);
 
         return () => {
-            document.removeEventListener('click', preventLinkNavigation, true);
-            document.removeEventListener('auxclick', preventLinkNavigation, true);
+            document.removeEventListener('click', preventLinkNavigation, CAPTURE_OPTIONS);
+            document.removeEventListener('auxclick', preventLinkNavigation, CAPTURE_OPTIONS);
+            document.removeEventListener('submit', preventFormNavigation, CAPTURE_OPTIONS);
         };
     }, [mask]);
 

--- a/src/components/PreviewPageMask/PreviewPageMask.tsx
+++ b/src/components/PreviewPageMask/PreviewPageMask.tsx
@@ -1,15 +1,45 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import { useMaskParam } from '@/hooks';
 
-import styles from './PreviewPageMask.module.scss';
+function getLinkFromEventTarget(target: EventTarget | null): HTMLAnchorElement | null {
+    if (!(target instanceof Element)) {
+        return null;
+    }
+
+    const link = target.closest('a[href]');
+
+    return link instanceof HTMLAnchorElement ? link : null;
+}
+
+function preventLinkNavigation(event: MouseEvent) {
+    const link = getLinkFromEventTarget(event.target);
+
+    if (!link) {
+        return;
+    }
+
+    event.preventDefault();
+}
 
 export function PreviewPageMask() {
     const mask = useMaskParam();
 
-    if (!mask) {
-        return null;
-    }
+    useEffect(() => {
+        if (!mask) {
+            return;
+        }
 
-    return <div className={styles.mask} />;
+        document.addEventListener('click', preventLinkNavigation, true);
+        document.addEventListener('auxclick', preventLinkNavigation, true);
+
+        return () => {
+            document.removeEventListener('click', preventLinkNavigation, true);
+            document.removeEventListener('auxclick', preventLinkNavigation, true);
+        };
+    }, [mask]);
+
+    return null;
 }


### PR DESCRIPTION
### Summary

- Replace the full-page PreviewPageMask overlay with a ?mask=true navigation lock that only blocks `<a href/>`  clicks/auxclicks. 
- Keeps in-app preview embeds interactive (YouTube, galleries, PDFs) while still preventing redirects away from the previewed story.

[screen-capture (6).webm](https://github.com/user-attachments/assets/8604d024-e89f-4866-a857-e0e977e1a114)
