### PR TITLE
Fix wrapped story image sizing 

### DIFF
--- a/src/components/ContentRenderer/ContentRenderer.module.scss
+++ b/src/components/ContentRenderer/ContentRenderer.module.scss
@@ -1,5 +1,4 @@
 $avatar-size: 60px;
-$wrapped-image-width: 320px;
 
 // This class is attached to ContentRenderer so that we can
 // modify some global styles for components that are coming
@@ -190,13 +189,16 @@ $wrapped-image-width: 320px;
         position: static;
         left: auto;
         right: auto;
-        width: min(50%, $wrapped-image-width);
-        margin: 0 $spacing-6 $spacing-4 0 !important;
+        margin: 8px 32px 8px 0 !important;
         text-align: left;
 
         :global {
             .prezly-slate-image__link,
-            .prezly-slate-image-rollover,
+            .prezly-slate-image-rollover {
+                width: 100% !important;
+                max-width: 100% !important;
+            }
+
             .prezly-slate-image__media,
             img,
             video {
@@ -215,7 +217,7 @@ $wrapped-image-width: 320px;
             float: right;
             clear: right;
             margin-right: 0 !important;
-            margin-left: $spacing-6 !important;
+            margin-left: 32px !important;
             text-align: right;
         }
     }

--- a/src/components/ContentRenderer/components/Image.tsx
+++ b/src/components/ContentRenderer/components/Image.tsx
@@ -3,7 +3,7 @@
 import { DOWNLOAD, VIEW } from '@prezly/analytics-nextjs';
 import { Elements } from '@prezly/content-renderer-react-js';
 import type { ImageNode } from '@prezly/story-content-format';
-import type { PropsWithChildren } from 'react';
+import type { CSSProperties, PropsWithChildren } from 'react';
 
 import { analytics } from '@/utils';
 import { CDN_URL } from '@/constants';
@@ -18,11 +18,25 @@ function isWrappedImageNode(node: ImageNode): boolean {
     return 'wrap' in node && node.wrap === true;
 }
 
+function getWrappedImageStyle(node: ImageNode): CSSProperties | undefined {
+    if (!isWrappedImageNode(node)) {
+        return undefined;
+    }
+
+    return {
+        ...(node.width ? { width: node.width } : {}),
+        maxWidth: `min(50%, ${node.file.original_width}px)`,
+    };
+}
+
 export function Image({ node, children }: PropsWithChildren<Props>) {
+    const isWrapped = isWrappedImageNode(node);
+
     return (
         <Elements.Image
-            className={isWrappedImageNode(node) ? styles.wrappedImage : undefined}
+            className={isWrapped ? styles.wrappedImage : undefined}
             node={node}
+            style={getWrappedImageStyle(node)}
             onDownload={(image) => {
                 analytics.track(DOWNLOAD.IMAGE, { id: image.uuid });
             }}


### PR DESCRIPTION
## Summary

Previously, the editor allowed choosing sizes for wrapped images, but the Bea theme renderer was overriding those values.
This PR makes the theme respect the wrapped image size:
- small renders at 200px
- best-fit renders at up to 360px, capped at half of the story row width

It also adjusts the wrapped image spacing in the theme, since the editor spacing does not apply to the rendered newsroom story.

Small:
<img width="1520" height="1618" alt="CleanShot 2026-08-20 at 10 09 18@2x" src="https://github.com/user-attachments/assets/ad6fc602-6b39-47a4-aa70-14f3c6eef287" />

Best-fit:
<img width="1590" height="1592" alt="CleanShot 2026-08-20 at 10 34 50@2x" src="https://github.com/user-attachments/assets/6e0b9f92-2141-46c8-be26-13c096e65cec" />
