### PR TITLE
[DEV-22714] Fix - Attached story media links in campaign emails

### DIFF
--- a/src/components/ContentRenderer/components/Image.tsx
+++ b/src/components/ContentRenderer/components/Image.tsx
@@ -3,7 +3,7 @@
 import { DOWNLOAD, VIEW } from '@prezly/analytics-nextjs';
 import { Elements } from '@prezly/content-renderer-react-js';
 import type { ImageNode } from '@prezly/story-content-format';
-import type { CSSProperties, PropsWithChildren } from 'react';
+import { type CSSProperties, type PropsWithChildren, useEffect } from 'react';
 
 import { analytics } from '@/utils';
 import { CDN_URL } from '@/constants';
@@ -31,6 +31,13 @@ function getWrappedImageStyle(node: ImageNode): CSSProperties | undefined {
 
 export function Image({ node, children }: PropsWithChildren<Props>) {
     const isWrapped = isWrappedImageNode(node);
+    const anchorId = `image-${node.file.uuid}`;
+
+    useEffect(() => {
+        if (window.location.hash === `#${anchorId}`) {
+            document.getElementById(anchorId)?.scrollIntoView();
+        }
+    }, [anchorId]);
 
     return (
         <Elements.Image

--- a/src/components/ContentRenderer/components/Video.tsx
+++ b/src/components/ContentRenderer/components/Video.tsx
@@ -4,7 +4,7 @@ import { MEDIA } from '@prezly/analytics-nextjs';
 import { Elements } from '@prezly/content-renderer-react-js';
 import { Newsroom } from '@prezly/sdk';
 import type { VideoNode } from '@prezly/story-content-format';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { ConsentCategory, useCookieConsent } from '@/modules/CookieConsent';
 import { analytics } from '@/utils';
@@ -17,6 +17,7 @@ interface Props {
 
 export function Video({ node }: Props) {
     const isEventTracked = useRef(false);
+    const anchorId = `video-${node.uuid}`;
     const { consent, trackingPolicy } = useCookieConsent();
     const canUseThirdPartyCookie =
         trackingPolicy === Newsroom.TrackingPolicy.LENIENT ||
@@ -29,8 +30,14 @@ export function Video({ node }: Props) {
         }
     }, []);
 
+    useEffect(() => {
+        if (window.location.hash === `#${anchorId}`) {
+            document.getElementById(anchorId)?.scrollIntoView();
+        }
+    }, [anchorId]);
+
     if (!canUseThirdPartyCookie && !isPrezlyUrl(node.url)) {
-        return <NoConsentFallback id={`video-${node.uuid}`} entity="video" oembed={node.oembed} />;
+        return <NoConsentFallback id={anchorId} entity="video" oembed={node.oembed} />;
     }
 
     return <Elements.Video node={node} onPlay={handlePlay} />;


### PR DESCRIPTION
- Fix attached story image and video links from campaign emails.
- Scroll to the matching content after page hydration.
- Support embedded video providers, custom YouTube rendering where applicable, and consent fallbacks.