### PR TITLE
Handle unavailable newsroom in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,6 @@
 import { Locale } from '@prezly/theme-kit-nextjs';
 import { IntlMiddleware } from '@prezly/theme-kit-nextjs/middleware';
-import type { NextRequest } from 'next/server';
+import { type NextRequest, NextResponse } from 'next/server';
 
 import { configureAppRouter, initPrezlyClient } from '@/adapters/server';
 
@@ -39,9 +39,15 @@ async function retrieveNewsroomLocalesFromApi(headers: Headers) {
 }
 
 export async function middleware(request: NextRequest) {
-    const locales =
-        parseNewsroomLocalesFromHeaders(request.headers) ??
-        (await retrieveNewsroomLocalesFromApi(request.headers));
+    let locales = parseNewsroomLocalesFromHeaders(request.headers);
+
+    if (!locales) {
+        try {
+            locales = await retrieveNewsroomLocalesFromApi(request.headers);
+        } catch {
+            return new NextResponse('Newsroom is temporarily unavailable.', { status: 503 });
+        }
+    }
 
     const [defaultLocale] = locales; // default is expected to always be the first in the list
 


### PR DESCRIPTION
The theme currently exposes an unhandled SDK exception as a generic 500 when Prezly cannot load the configured newsroom locales. The middleware now catches that lookup failure and returns a clear 503 response: `Newsroom is temporarily unavailable.`

## Verification

- `corepack pnpm@10.25.0 check` passed, 340 files checked
- `corepack pnpm@10.25.0 typecheck` passed
- `jude-env curl app /` returned the expected 503 and message
- A clean Jude log window reported zero new runtime errors

The Jude endpoint cannot pass its reachability check because the session newsroom `2c60c5ce-a21f-4e0f-baa7-7eb3a515d2c4` still returns 404 from Prezly, which is the environment failure handled by this change. Browser verification was unavailable because the T3 endpoint is down.

<details>
<summary>Jude verification output</summary>

```json
{
  "schemaVersion": "1.0",
  "generatedAt": "2026-09-04T13:29:30Z",
  "baselineAt": "2026-09-04T13:29:26Z",
  "session": {
    "id": "theme-nextjs-bea-test-prezly-code-vrt",
    "project": "theme-nextjs-bea",
    "repository": "https://github.com/prezly/theme-nextjs-bea",
    "ref": "main"
  },
  "source": {
    "revision": "b39cacc8392c144cfd5a98255311c95cbe3b5343",
    "worktree": "clean",
    "repository": "https://github.com/prezly/theme-nextjs-bea",
    "passed": true
  },
  "endpointChecks": [
    {
      "name": "App",
      "url": "https://theme-nextjs-bea-test-prezly-code-vrt.themes.jude.prezly.dev",
      "required": true,
      "check": "reachability",
      "status": 503,
      "passed": false
    },
    {
      "name": "OpenCode 2",
      "url": "https://theme-nextjs-bea-test-prezly-code-vrt.opencode2.jude.prezly.dev",
      "required": false,
      "check": "reachability",
      "status": 401,
      "passed": true
    },
    {
      "name": "T3",
      "url": "https://theme-nextjs-bea-test-prezly-code-vrt.t3.jude.prezly.dev",
      "required": false,
      "check": "reachability",
      "status": 0,
      "passed": false
    }
  ],
  "logChecks": [
    {
      "service": "app",
      "since": "2026-09-04T13:29:26Z",
      "passed": true,
      "runtimeErrors": false,
      "newRuntimeErrorCount": 0,
      "recentHistoricalRuntimeErrorCount": 27,
      "historicalSampleTail": 200,
      "error": null
    }
  ],
  "overall": {
    "passed": false
  }
}
```

</details>
